### PR TITLE
Remove save data verification

### DIFF
--- a/src/dx/versioning.c
+++ b/src/dx/versioning.c
@@ -35,23 +35,6 @@ void fio_serialize_state() {
 void fio_deserialize_state() {
     SaveData* saveData = &gCurrentSaveFile;
 
-    if (saveData->modName[0] == '\0') {
-        // normally a mod should not be able to load a normal Paper Mario save
-        // however, if you would like your mod to support this, remove this PANIC
-        PANIC_MSG("Cannot load unmodded save");
-        ver_deserialize_vanilla_save(saveData);
-    } else if (strcmp(saveData->modName, DX_MOD_NAME) != 0) {
-        // always prevent loading data from other mods
-        char error[0x40] = "Cannot load save from: ";
-        strcat(error, saveData->modName);
-        PANIC_MSG(error);
-    } else if (saveData->majorVersion != DX_MOD_VER_MAJOR) {
-        // handle breaking changes between major versions here
-        ver_deserialize_standard(saveData);
-    } else {
-        ver_deserialize_standard(saveData);
-    }
-
     gGameStatus.debugEnemyContact = DEBUG_CONTACT_NONE;
     gGameStatus.debugUnused1 = FALSE;
     gGameStatus.debugUnused2 = FALSE;

--- a/src/dx/versioning.c
+++ b/src/dx/versioning.c
@@ -35,6 +35,13 @@ void fio_serialize_state() {
 void fio_deserialize_state() {
     SaveData* saveData = &gCurrentSaveFile;
 
+    if (saveData->majorVersion != DX_MOD_VER_MAJOR) {
+        // handle breaking changes between major versions here
+        ver_deserialize_standard(saveData);
+    } else {
+        ver_deserialize_standard(saveData);
+    }
+    
     gGameStatus.debugEnemyContact = DEBUG_CONTACT_NONE;
     gGameStatus.debugUnused1 = FALSE;
     gGameStatus.debugUnused2 = FALSE;
@@ -47,12 +54,7 @@ void ver_deserialize_standard() {
     SaveData* saveData = &gCurrentSaveFile;
     s32 i, j;
 
-    if (saveData->majorVersion != DX_MOD_VER_MAJOR) {
-        // handle breaking changes between major versions here
-        ver_deserialize_standard(saveData);
-    } else {
-        ver_deserialize_standard(saveData);
-    }
+
 
     // simply copy the saved player data
     gPlayerData = saveData->player;

--- a/src/dx/versioning.c
+++ b/src/dx/versioning.c
@@ -47,6 +47,13 @@ void ver_deserialize_standard() {
     SaveData* saveData = &gCurrentSaveFile;
     s32 i, j;
 
+    if (saveData->majorVersion != DX_MOD_VER_MAJOR) {
+        // handle breaking changes between major versions here
+        ver_deserialize_standard(saveData);
+    } else {
+        ver_deserialize_standard(saveData);
+    }
+
     // simply copy the saved player data
     gPlayerData = saveData->player;
 


### PR DESCRIPTION
If we're going to standardize dx, this simply has to go. If you want an alternative solution then go make one, but the current approach won't do. It completely blocks console players from playing the game at all and it causes unnecessary hassle for emulator players too.

<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->