### PR TITLE
Fix Action Commands not working before obtaining any badges

### DIFF
--- a/src/battle/btl_states_actions.c
+++ b/src/battle/btl_states_actions.c
@@ -261,7 +261,7 @@ void btl_state_update_normal_start(void) {
             gCameras[CAM_DEFAULT].flags |= CAMERA_FLAG_DISABLED;
             gCameras[CAM_BATTLE].flags |= CAMERA_FLAG_DISABLED;
             gCameras[CAM_TATTLE].flags |= CAMERA_FLAG_DISABLED;
-            if (is_ability_active(ABILITY_MYSTERY_SCROLL)) {
+            if (gPlayerData.hasActionCommands) {
                 battleStatus->actionCommandMode = ACTION_COMMAND_MODE_LEARNED;
             }
             battleStatus->actionSuccess = 0;


### PR DESCRIPTION
If a mod enables action commands at the start of the game via `gPlayerData.hasActionCommands`, then they still won't work until the player obtains a badge, due to previous changes to `is_ability_active` done by dx - the game handles the AC check in a very weird way...
This PR fixes this bug.