### PR TITLE
Fix slide in iwa_03

### DIFF
--- a/src/world/area_iwa/iwa_03/iwa_03_1_main.c
+++ b/src/world/area_iwa/iwa_03/iwa_03_1_main.c
@@ -1,5 +1,17 @@
 #include "iwa_03.h"
 
+b32 N(should_player_be_sliding)(void) {
+    Shadow* shadow = get_shadow_by_index(gPlayerStatus.shadowID);
+    f32 angle = shadow->rot.z + 180.0;
+
+    return (angle != 0.0f) && (fabsf(angle) >= 20.0f);
+}
+
+API_CALLABLE(N(SetupSlidingCheck)) {
+    phys_set_player_sliding_check(N(should_player_be_sliding));
+    return ApiStatus_DONE2;
+}
+
 EvtScript N(EVS_ExitWalk_iwa_01_1) = EVT_EXIT_WALK(60, iwa_03_ENTRY_0, "iwa_01", iwa_01_ENTRY_1);
 
 EvtScript N(EVS_BindExitTriggers) = {
@@ -11,6 +23,7 @@ EvtScript N(EVS_BindExitTriggers) = {
 EvtScript N(EVS_Main) = {
     Set(GB_WorldLocation, LOCATION_MT_RUGGED)
     Call(SetSpriteShading, SHADING_NONE)
+    Call(N(SetupSlidingCheck))
     EVT_SETUP_CAMERA_DEFAULT(0, 0, 0)
     Call(MakeNpcs, TRUE, Ref(N(DefaultNPCs)))
     ExecWait(N(EVS_MakeEntities))


### PR DESCRIPTION
DX changes in commit https://github.com/bates64/papermario-dx/commit/1b85148e46f856917abe0fbf933bdac6cafcf509 break the slide in iwa_03, as it doesn't call `phys_set_player_sliding_check`, unlike the remaining iwa maps with slides.

This PR fixes this bug by doing the same thing that commit did in the remaining iwa maps.