### PR TITLE
Improve 5 BP cost badge rendering

### DIFF
--- a/src/pause/pause_badges.c
+++ b/src/pause/pause_badges.c
@@ -549,7 +549,7 @@ void pause_badges_draw_contents(MenuPanel* menu, s32 baseX, s32 baseY, s32 width
                             gDPSetPrimColor(gMainGfxPos++, 0, 0, 227, 227, 227, 255);
                             orbX = baseX + 235 + pause_badges_scroll_offset_x(posX) + 1 + (j % 5) * 6;
                             orbY = baseY + 17 + pause_badges_scroll_offset_y(posY) + orbOffsetY;
-                            if (numOrbs >= 5) {
+                            if (numOrbs > 5) {
                                 orbY += j / 5 * 6 - 3;
                             }
                             pause_badges_draw_bp_orbs(0, orbX, orbY);
@@ -563,7 +563,7 @@ void pause_badges_draw_contents(MenuPanel* menu, s32 baseX, s32 baseY, s32 width
                             if (j < bpAvailable) {
                                 orbX = baseX + 235 + pause_badges_scroll_offset_x(posX) + 1 + (j % 5) * 6;
                                 orbY = baseY + 17 + pause_badges_scroll_offset_y(posY) + orbOffsetY;
-                                if (numOrbs >= 5) {
+                                if (numOrbs > 5) {
                                     orbY += j / 5 * 6 - 3;
                                 }
                                 pause_badges_draw_bp_orbs(1, orbX, orbY);
@@ -574,7 +574,7 @@ void pause_badges_draw_contents(MenuPanel* menu, s32 baseX, s32 baseY, s32 width
                         for (j = 0; j < numOrbs; j++) {
                             orbX = baseX + 235 + pause_badges_scroll_offset_x(posX) + 1 + (j % 5) * 6;
                             orbY = baseY + 17 + pause_badges_scroll_offset_y(posY) + orbOffsetY;
-                            if (numOrbs >= 5) {
+                            if (numOrbs > 5) {
                                 orbY += j / 5 * 6 - 3;
                             }
                             pause_badges_draw_bp_orbs(2, orbX, orbY);


### PR DESCRIPTION
Currently, badges costing 5BP get their bp orbs rendered off-centered, even though they get rendered in 1 line. This PR fixes that.
![5Bp](https://github.com/bates64/papermario-dx/assets/50085307/c37c9d08-f992-46df-9d13-335d2618d673)
