### PR TITLE
Fix dependency checksum error during initial setup

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ let
 
   egcs-gcc = builtins.fetchurl {
     url =
-      "https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/latest/download/mips-gcc-egcs-2.91.66-linux.tar.gz";
+      "https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.2/mips-gcc-egcs-2.91.66-linux.tar.gz";
     sha256 = "03v1ci7j0hi53z639rwj60xwz0zzi82a9azi0yiw818r754faql0";
   };
 


### PR DESCRIPTION
The provided URL for `mips-gcc-egcs-2.91.66-linux.tar.gz` within `./shell.nix` points to the `latest` release of that repository.

However, that repository recently saw new releases, so a different file now gets downloaded and the provided checksum for that file no longer matches.

```
error: hash mismatch in file downloaded from 'https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/latest/download/mips-gcc-egcs-2.91.66-linux.tar.gz':
         specified: sha256:03v1ci7j0hi53z639rwj60xwz0zzi82a9azi0yiw818r754faql0
         got:       sha256:1fdvlah66r26c4fvy4j97f2bqaair19bbbg4z3x0qz16iphhzmhx
```

This PR pins the release of that dependency to its version 0.2, which matches the provided sha256 checksum.

As an alternative to this PR, if an update to a newer version of the dependency is being considered, I recommend both updating the sha256 to the current up-to-date version of 0.4, as well as pinning the dependency to said version.

For reference, see https://github.com/decompals/mips-gcc-egcs-2.91.66/releases