### PR TITLE
Fix Toy Box box puzzle

### DIFF
--- a/src/evt/evt.c
+++ b/src/evt/evt.c
@@ -869,7 +869,7 @@ ApiStatus evt_handle_OR(Evt* script) {
     s32 bits = evt_get_variable(script, *args++);
     s32 prev = evt_get_variable(script, var);
 
-    evt_set_variable(script, bits, prev | bits);
+    evt_set_variable(script, var, prev | bits);
     return ApiStatus_DONE2;
 }
 


### PR DESCRIPTION
So as it turns out, the Toy Box box puzzle is the only script in the game that calls `BitwiseOr()`. It was accidentally broken by a typo a bit ago, but this fixes it. Addresses #68.