### PR TITLE
Fix Stop Leech action commands from crashing upon finish

### DIFF
--- a/src/battle/action_cmd.c
+++ b/src/battle/action_cmd.c
@@ -465,7 +465,7 @@ void action_command_free(void) {
             action_command_whirlwind_free();
             break;
         case ACTION_COMMAND_STOP_LEECH:
-            action_command_jump_draw();
+            action_command_stop_leech_free();
             break;
         case ACTION_COMMAND_07:
             action_command_07_free();


### PR DESCRIPTION
So somehow even though this bug [exists in vanilla decomp](https://github.com/pmret/papermario/blob/efd86abeac9865bafc7a9ead420ae6c24119bb9b/src/battle/action_cmd.c#L468), it's only causing issues in dx. Addresses #69, though it applies to all enemies that use this action command, such as Swoopulas, Jungle Fuzzies, etc.