### PR TITLE
feat: clangd support

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+  Add: -Wno-unknown-warning-option
+  Remove: [-m*, -f*]

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ build/
 *.crash
 
 /tools/n64crc
+
+# clangd
+.cache/clangd/
+# compile_commands.json requires hardcoded paths, so it can't be committed
+compile_commands.json


### PR DESCRIPTION
This adds:
- a configuration file for clangd (to ignore flags clang doesn't support)
- `.gitignore` entry for clangd's cache directory

It also adds `compile_commands.json` to `.gitignore` because it must be generated by the user themselves. This is because it requires hardcoded paths. I've also opened a PR on the Star Haven docs with instructions for generating this file: https://github.com/star-haven/docs/pull/5