### PR TITLE
Add slimmed down ASSERT for effects

### DIFF
--- a/include/effects_internal.h
+++ b/include/effects_internal.h
@@ -3,6 +3,12 @@
 
 #include "effects.h"
 
+// slimmed down assert so that all effects still fit under the TLB page size limit of 0x1000 bytes
+#define ASSERT(condition) \
+    if (!(condition)) { \
+        IS_DEBUG_PANIC("Assert", __FILE_NAME__, __LINE__, NULL); \
+    }
+
 s32 effect_rand_int(s32);
 s32 effect_simple_rand(s32, s32);
 

--- a/src/crash_screen.c
+++ b/src/crash_screen.c
@@ -77,7 +77,7 @@ void crash_screen_set_assert_info(const char* message, const char* file, u32 lin
         }
         file = slash + 1;
     }
-    sprintf(crashScreenAssertLocation, "%s (%s:%d)", func, file, line);
+    sprintf(crashScreenAssertLocation, "%s (%s:%d)", func == NULL ? "Unknown" : func, file, line);
 }
 
 void crash_screen_sleep(s32 ms) {


### PR DESCRIPTION
Fixes #95 and fixes #67.

In order to fit into a TLB page, effects must be no more than `0x1000` bytes in size. With the expanded context that dx has added to `ASSERT`, three effects are pushed over the limit, causing crashes: `EFFECT_AURA`, `EFFECT_TUBBA_HEART_ATTACK`, and `EFFECT_FIREWORK_ROCKET`.

To bring the size back down, I've given effects a slimmed down version of `ASSERT` that provides only the word "Assert", the filename without the full path, and the line number. This *barely* gets the size down low enough. `EFFECT_FIREWORK_ROCKET` is at exactly `0x1000` bytes and the other two are at `0xfe0`, but they do work now.

Now even this much context is pretty useless since backtraces don't work with the TLB, but once that's implemented, the information is there. For now I took a screenshot to show what it looks like if the slimmed down `ASSERT` is used elsewhere.

![image](https://github.com/user-attachments/assets/517ba1d8-c8e2-4827-b079-b1071d828d8d)