### PR TITLE
Fix __FILE__ macro

### DIFF
--- a/include/effect_shims.h
+++ b/include/effect_shims.h
@@ -37,7 +37,7 @@ void shim_draw_msg(s32, s32, s32, s32, s32, s32);
 s32 shim_get_msg_width(s32, u16);
 void shim_mdl_get_shroud_tint_params(u8* r, u8* g, u8* b, u8* a);
 void shim_sfx_play_sound_at_position(s32 soundID, s32 value2, f32 posX, f32 posY, f32 posZ);
-void shim_is_debug_panic(const char* message, const char* file, u32 line, const char* func);
+void shim_is_debug_panic(const char* message);
 
 #define guRotateF shim_guRotateF
 #define guTranslateF shim_guTranslateF

--- a/include/effects_internal.h
+++ b/include/effects_internal.h
@@ -6,7 +6,7 @@
 // slimmed down assert so that all effects still fit under the TLB page size limit of 0x1000 bytes
 #define ASSERT(condition) \
     if (!(condition)) { \
-        IS_DEBUG_PANIC("Assert", __FILE__, __LINE__, NULL); \
+        IS_DEBUG_PANIC("ASSERT"); \
     }
 
 s32 effect_rand_int(s32);

--- a/include/effects_internal.h
+++ b/include/effects_internal.h
@@ -6,7 +6,7 @@
 // slimmed down assert so that all effects still fit under the TLB page size limit of 0x1000 bytes
 #define ASSERT(condition) \
     if (!(condition)) { \
-        IS_DEBUG_PANIC("Assert", __FILE_NAME__, __LINE__, NULL); \
+        IS_DEBUG_PANIC("Assert", __FILE__, __LINE__, NULL); \
     }
 
 s32 effect_rand_int(s32);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1069,6 +1069,7 @@ void clear_character_set(void);
 void clear_trigger_data(void);
 void clear_script_list(void);
 void clear_entity_data(b32);
+void init_effect_data(void);
 void clear_effect_data(void);
 
 void clear_saved_variables(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -17,7 +17,7 @@ void boot_idle(void* data);
 void boot_main(void* data);
 
 void is_debug_init(void);
-void is_debug_panic(const char* message, const char* file, u32 line, const char* func);
+void is_debug_panic(const char* message);
 
 f32 signF(f32 val);
 
@@ -1069,7 +1069,7 @@ void clear_character_set(void);
 void clear_trigger_data(void);
 void clear_script_list(void);
 void clear_entity_data(b32);
-void init_effect_data(void);
+void check_effect_sizes(void);
 void clear_effect_data(void);
 
 void clear_saved_variables(void);

--- a/include/macros.h
+++ b/include/macros.h
@@ -35,27 +35,27 @@
 #define VIRTUAL_TO_PHYSICAL(addr) (u32)((u8*)(addr) - 0x80000000)
 
 //#ifdef DEBUG
-#define IS_DEBUG_PANIC(statement, file, line, func) is_debug_panic(statement, file, line, func)
+#define IS_DEBUG_PANIC(statement) is_debug_panic(statement)
 /*#else
-#define IS_DEBUG_PANIC(statement, file, line, func) do {} while(TRUE)
+#define IS_DEBUG_PANIC(statement) do {} while(TRUE)
 #endif*/
 
-#define PANIC() IS_DEBUG_PANIC("Panic", __FILE__, __LINE__, __func__)
+#define PANIC() IS_DEBUG_PANIC("Panic")
 #define PANIC_MSG(msg, args...) \
     do { \
         char panicMsg[0x40]; \
         sprintf(panicMsg, msg, ##args); \
-        IS_DEBUG_PANIC(msg, __FILE__, __LINE__, __func__); \
+        IS_DEBUG_PANIC(msg); \
     } while (0)
 #define ASSERT(condition) \
     if (!(condition)) { \
-        IS_DEBUG_PANIC("Assertion failed: " #condition, __FILE__, __LINE__, __func__); \
+        IS_DEBUG_PANIC("Assertion failed: " #condition); \
     }
 #define ASSERT_MSG(condition, msg, args...) \
     if (!(condition)) { \
         char assertMsg[0x40]; \
         sprintf(assertMsg, msg, ##args); \
-        IS_DEBUG_PANIC(assertMsg, __FILE__, __LINE__, __func__); \
+        IS_DEBUG_PANIC(assertMsg); \
     }
 
 #define BADGE_MENU_PAGE(index) (&gPauseBadgesPages[index])

--- a/src/crash_screen.c
+++ b/src/crash_screen.c
@@ -68,15 +68,6 @@ char crashScreenAssertLocation[0x30] = {0};
 void crash_screen_set_assert_info(const char* message, const char* file, u32 line, const char* func) {
     strncpy(crashScreenAssertMessage, message, sizeof(crashScreenAssertMessage));
     crashScreenAssertMessage[sizeof(crashScreenAssertMessage) - 1] = '\0';
-
-    // To make file consistent with standard exceptions, grab only the filename, not the full path.
-    const char* slash;
-    while (slash = strchr(file, '/')) {
-        if (slash[1] == '\0') {
-            break;
-        }
-        file = slash + 1;
-    }
     sprintf(crashScreenAssertLocation, "%s (%s:%d)", func == NULL ? "Unknown" : func, file, line);
 }
 

--- a/src/crash_screen.c
+++ b/src/crash_screen.c
@@ -63,12 +63,10 @@ const char* gFPCSRFaultCauses[6] = {
 };
 
 char crashScreenAssertMessage[0x30] = {0};
-char crashScreenAssertLocation[0x30] = {0};
 
-void crash_screen_set_assert_info(const char* message, const char* file, u32 line, const char* func) {
+void crash_screen_set_assert_info(const char* message) {
     strncpy(crashScreenAssertMessage, message, sizeof(crashScreenAssertMessage));
     crashScreenAssertMessage[sizeof(crashScreenAssertMessage) - 1] = '\0';
-    sprintf(crashScreenAssertLocation, "%s (%s:%d)", func == NULL ? "Unknown" : func, file, line);
 }
 
 void crash_screen_sleep(s32 ms) {
@@ -323,12 +321,11 @@ void crash_screen_draw(OSThread* faultedThread) {
 
     crash_screen_draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
-    if (crashScreenAssertMessage[0] == '\0' || crashScreenAssertLocation[0] == '\0') {
+    if (crashScreenAssertMessage[0] == '\0') {
         crash_screen_printf_proportional(x, y += 10, "Exception in thread %d: %s", faultedThread->id, gFaultCauses[causeIndex]);
     } else {
         crash_screen_printf_proportional(x, y += 10, crashScreenAssertMessage);
-        crash_screen_printf_proportional(x + 10, y += 10, "at %s", crashScreenAssertLocation);
-        i = 2; // Don't include is_debug_panic and ASSERT line in backtrace.
+        i = 1; // Don't include is_debug_panic line in backtrace.
     }
 
     for (; i < max; i++) {

--- a/src/effect_utils.c
+++ b/src/effect_utils.c
@@ -10,7 +10,8 @@ void* effectFuncs[] = {
     cos_deg, atan2, npc_raycast_down_sides, load_effect, sqrtf, mdl_draw_hidden_panel_surface, is_point_visible,
     guPerspectiveF, guMtxIdentF, transform_point, guLookAtHiliteF, set_screen_overlay_params_back,
     set_screen_overlay_center, set_screen_overlay_center_worldpos, mdl_get_next_texture_address, guPositionF, guOrthoF,
-    guFrustumF, draw_prev_frame_buffer_at_screen_pos, draw_box, draw_msg, get_msg_width, mdl_get_shroud_tint_params, sfx_play_sound_at_position
+    guFrustumF, draw_prev_frame_buffer_at_screen_pos, draw_box, draw_msg, get_msg_width, mdl_get_shroud_tint_params,
+    sfx_play_sound_at_position, is_debug_panic
 };
 
 s32 SimpleRandLUT[128] = {

--- a/src/effects.c
+++ b/src/effects.c
@@ -39,7 +39,9 @@ void check_effect_sizes(void) {
 
     for (i = 0; i < ARRAY_COUNT(gEffectTable); i++) {
         s32 size = gEffectTable[i].dmaEnd - gEffectTable[i].dmaStart;
-        ASSERT_MSG(size <= 0x1000, "Effect 0x%x == 0x%x bytes (0x1000 limit)", i, size);
+        if (size > 0x1000) {
+            osSyncPrintf("WARNING: Effect 0x%x == 0x%x bytes (0x1000 limit)\n", i, size);
+        }
     }
 }
 

--- a/src/effects.c
+++ b/src/effects.c
@@ -34,14 +34,13 @@ void set_effect_pos_offset(EffectInstance* effect, f32 x, f32 y, f32 z) {
     ((f32*)data)[3] = z;
 }
 
-void init_effect_data(void) {
+void check_effect_sizes(void) {
     s32 i;
 
     for (i = 0; i < ARRAY_COUNT(gEffectTable); i++) {
         s32 size = gEffectTable[i].dmaEnd - gEffectTable[i].dmaStart;
         ASSERT_MSG(size <= 0x1000, "Effect 0x%x == 0x%x bytes (0x1000 limit)", i, size);
     }
-    clear_effect_data();
 }
 
 void clear_effect_data(void) {

--- a/src/effects.c
+++ b/src/effects.c
@@ -34,6 +34,16 @@ void set_effect_pos_offset(EffectInstance* effect, f32 x, f32 y, f32 z) {
     ((f32*)data)[3] = z;
 }
 
+void init_effect_data(void) {
+    s32 i;
+
+    for (i = 0; i < ARRAY_COUNT(gEffectTable); i++) {
+        s32 size = gEffectTable[i].dmaEnd - gEffectTable[i].dmaStart;
+        ASSERT_MSG(size <= 0x1000, "Effect 0x%x == 0x%x bytes (0x1000 limit)", i, size);
+    }
+    clear_effect_data();
+}
+
 void clear_effect_data(void) {
     s32 i;
 

--- a/src/is_debug.c
+++ b/src/is_debug.c
@@ -2,7 +2,7 @@
 #include "stdlib/stdarg.h"
 #include "nu/nusys.h"
 
-void crash_screen_set_assert_info(const char* message, const char* file, u32 line, const char* func);
+void crash_screen_set_assert_info(const char* message);
 typedef struct {
     /* 0x00 */ u32 magic;
     /* 0x04 */ u32 get;
@@ -90,7 +90,7 @@ char* is_debug_print(char* arg0, const char* str, size_t count) {
     return (char*) 1;
 }
 
-void is_debug_panic(const char* message, const char* file, u32 line, const char* func) {
-    crash_screen_set_assert_info(message, file, line, func);
+void is_debug_panic(const char* message) {
+    crash_screen_set_assert_info(message);
     *(volatile u32*)0 = 0; // Crash so we can see the crash screen
 }

--- a/src/main_loop.c
+++ b/src/main_loop.c
@@ -330,7 +330,8 @@ void load_engine_data(void) {
     clear_player_data();
     init_encounter_status();
     clear_screen_overlays();
-    init_effect_data();
+    check_effect_sizes();
+    clear_effect_data();
     clear_saved_variables();
     clear_item_entity_data();
     bgm_reset_sequence_players();

--- a/src/main_loop.c
+++ b/src/main_loop.c
@@ -330,7 +330,7 @@ void load_engine_data(void) {
     clear_player_data();
     init_encounter_status();
     clear_screen_overlays();
-    clear_effect_data();
+    init_effect_data();
     clear_saved_variables();
     clear_item_entity_data();
     bgm_reset_sequence_players();

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -683,7 +683,7 @@ class Configure:
                     elif "os" in entry.src_paths[0].parts:  # libultra
                         cflags = ""
                     else:  # papermario
-                        cflags = f"-fforce-addr -fmacro-prefix-map={str(entry.src_paths[0]).rsplit('/', 1)[0]}/="
+                        cflags = "-fforce-addr"
 
                 # c
                 task = "cc"

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -683,7 +683,7 @@ class Configure:
                     elif "os" in entry.src_paths[0].parts:  # libultra
                         cflags = ""
                     else:  # papermario
-                        cflags = "-fforce-addr"
+                        cflags = f"-fforce-addr -fmacro-prefix-map={str(entry.src_paths[0]).rsplit('/', 1)[0]}/="
 
                 # c
                 task = "cc"

--- a/tools/build/mapfs/map_header.py
+++ b/tools/build/mapfs/map_header.py
@@ -5,6 +5,7 @@ from os import path
 from xml.dom.minidom import parse
 from pathlib import Path
 
+
 def eprint(*args, **kwargs):
     print(*args, file=stderr, **kwargs)
 


### PR DESCRIPTION
So it turns out `__FILE_NAME__` wasn't implemented until gcc-12, which isn't standard in Ubuntu until 24.04. The GitHub action won't be a problem once `ubuntu-latest` has finished its rollout to that version by the end of this month, but it's still a bit of an unreasonable requirement for users. Instead, this uses `-fmacro-prefix-map` to remove the path from `__FILE__` at compile time. I also went ahead and applied it throughout the whole project, which will save a bit of space anywhere asserts are used, and as far as I can tell it isn't breaking anything.

Additionally, I added a runtime check at boot for effect sizes. Doing it at compile time will of course be better, but until that's implemented I thought I might as well add it.

And finally, python formatting was fixed so the Python Formatting & Linting action stops failing.