### PR TITLE
Enforce effect size limits at build time

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1069,7 +1069,6 @@ void clear_character_set(void);
 void clear_trigger_data(void);
 void clear_script_list(void);
 void clear_entity_data(b32);
-void check_effect_sizes(void);
 void clear_effect_data(void);
 
 void clear_saved_variables(void);

--- a/src/effects.c
+++ b/src/effects.c
@@ -34,17 +34,6 @@ void set_effect_pos_offset(EffectInstance* effect, f32 x, f32 y, f32 z) {
     ((f32*)data)[3] = z;
 }
 
-void check_effect_sizes(void) {
-    s32 i;
-
-    for (i = 0; i < ARRAY_COUNT(gEffectTable); i++) {
-        s32 size = gEffectTable[i].dmaEnd - gEffectTable[i].dmaStart;
-        if (size > 0x1000) {
-            osSyncPrintf("WARNING: Effect 0x%x == 0x%x bytes (0x1000 limit)\n", i, size);
-        }
-    }
-}
-
 void clear_effect_data(void) {
     s32 i;
 

--- a/src/main_loop.c
+++ b/src/main_loop.c
@@ -330,7 +330,6 @@ void load_engine_data(void) {
     clear_player_data();
     init_encounter_status();
     clear_screen_overlays();
-    check_effect_sizes();
     clear_effect_data();
     clear_saved_variables();
     clear_item_entity_data();

--- a/tools/build/check_section_sizes.py
+++ b/tools/build/check_section_sizes.py
@@ -1,0 +1,41 @@
+from sys import argv
+import json
+import subprocess
+import sys
+
+# Checks each segment-size pair in JSON object are valid for the given ELF.
+# usage: python3 check_section_sizes.py <elf> <json>
+
+argv.pop(0) # python3
+elf_path = argv.pop(0)
+jsonstr = argv.pop(0)
+
+def read_elf():
+    result = subprocess.run(["mips-linux-gnu-nm", elf_path], stdout=subprocess.PIPE)
+    lines = result.stdout.decode().split("\n")
+    symbols = {}
+    for line in lines:
+        splitted = line.split(" ")
+        if len(splitted) == 3:
+            address, kind, symbol = splitted
+            if symbol.endswith("_VRAM") or symbol.endswith("_VRAM_END"):
+                symbols[symbol] = int(address, 16)
+    return symbols
+
+segment_size_map = json.loads(jsonstr)
+symbols = read_elf()
+
+fail = False
+for segment_name, max_size in segment_size_map.items():
+    start_address = symbols[segment_name + "_VRAM"]
+    end_address = symbols[segment_name + "_VRAM_END"]
+    true_size = end_address - start_address
+    if true_size > max_size:
+        size_diff = true_size - max_size
+        print(f"\033[31msegment '{segment_name}' is oversized!\033[0m (size is {true_size:X}; +{size_diff:X} compared to max size {max_size:X})", file=sys.stderr)
+        fail = True
+if fail:
+    print("help: segment(s) are too big to fit in their overlay(s). to fix this, write less code/data, or modify the engine and splat.yaml to increase the limit", file=sys.stderr)
+    exit(1)
+else:
+    print("ok")

--- a/tools/build/check_segment_sizes.py
+++ b/tools/build/check_segment_sizes.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 # Checks each segment-size pair in JSON object are valid for the given ELF.
-# usage: python3 check_section_sizes.py <elf> <json>
+# usage: python3 check_segment_sizes.py <elf> <json>
 
 argv.pop(0) # python3
 elf_path = argv.pop(0)

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -328,7 +328,11 @@ def write_ninja_rules(
 
     ninja.rule("flips", command=f"bash -c '{BUILD_TOOLS}/floating/flips $baserom $in $out || true'")
 
-    ninja.rule("check_section_sizes", command=f"$python {BUILD_TOOLS}/check_section_sizes.py $in $data > $out")
+    ninja.rule(
+        "check_segment_sizes",
+        description="check segment sizes $in",
+        command=f"$python {BUILD_TOOLS}/check_segment_sizes.py $in $data > $out",
+    )
 
 
 def write_ninja_for_tools(ninja: ninja_syntax.Writer):
@@ -1281,9 +1285,10 @@ class Configure:
         else:
             ninja.build(
                 str(self.rom_ok_path()),
-                "check_section_sizes",
+                "check_segment_sizes",
                 str(self.elf_path()),
-                variables={"data": json.dumps(json.dumps(self.get_segment_max_sizes(), separators=(',', ':')))}
+                variables={"data": json.dumps(json.dumps(self.get_segment_max_sizes(), separators=(',', ':')))},
+                implicit=[str(self.rom_path())],
             )
 
         ninja.build(

--- a/ver/us/splat.yaml
+++ b/ver/us/splat.yaml
@@ -4785,7 +4785,7 @@ segments:
     vram: 0xE00D6000
     max_size: 0x1000
     subsegments:
-    - [auto, c, energy_in_out]
+    - [auto, c, energy_in_out, -Oz]
   - name: effect_gfx_energy_in_out
     dir: effects/gfx
     type: code

--- a/ver/us/splat.yaml
+++ b/ver/us/splat.yaml
@@ -4785,7 +4785,7 @@ segments:
     vram: 0xE00D6000
     max_size: 0x1000
     subsegments:
-    - [auto, c, energy_in_out, -Oz]
+    - [auto, c, energy_in_out, -Os]
   - name: effect_gfx_energy_in_out
     dir: effects/gfx
     type: code

--- a/ver/us/splat.yaml
+++ b/ver/us/splat.yaml
@@ -1692,6 +1692,7 @@ segments:
     type: code
     start: 0x3278F0
     vram: 0xE0002000
+    max_size: 0x1000
     subsegments:
     - [auto, c, big_smoke_puff]
   - name: effect_landing_dust
@@ -1699,6 +1700,7 @@ segments:
     type: code
     start: 0x328110
     vram: 0xE000C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, landing_dust]
   - name: effect_gfx_landing_dust
@@ -1752,6 +1754,7 @@ segments:
     type: code
     start: 0x32C110
     vram: 0xE000E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, walking_dust]
   - name: effect_flower_splash
@@ -1759,6 +1762,7 @@ segments:
     type: code
     start: 0x32C7A0
     vram: 0xE0010000
+    max_size: 0x1000
     subsegments:
     - [auto, c, flower_splash]
   - name: effect_gfx_flower_splash_trail
@@ -1797,6 +1801,7 @@ segments:
     type: code
     start: 0x32DD10
     vram: 0xE0012000
+    max_size: 0x1000
     subsegments:
     - [auto, c, flower_trail]
   - name: effect_cloud_puff
@@ -1804,6 +1809,7 @@ segments:
     type: code
     start: 0x32E490
     vram: 0xE0014000
+    max_size: 0x1000
     subsegments:
     - [auto, c, cloud_puff]
   - name: effect_gfx_cloud_puff_trail
@@ -1829,6 +1835,7 @@ segments:
     type: code
     start: 0x32EE30
     vram: 0xE0016000
+    max_size: 0x1000
     subsegments:
     - [auto, c, cloud_trail]
   - name: effect_footprint
@@ -1836,6 +1843,7 @@ segments:
     type: code
     start: 0x32F580
     vram: 0xE0018000
+    max_size: 0x1000
     subsegments:
     - [auto, c, footprint]
   - name: effect_gfx_footprint
@@ -1859,6 +1867,7 @@ segments:
     type: code
     start: 0x32FE30
     vram: 0xE001A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, floating_flower]
   - name: effect_gfx_floating_flower
@@ -1886,6 +1895,7 @@ segments:
     type: code
     start: 0x330910
     vram: 0xE001C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, snowflake]
   - name: effect_gfx_snowflake
@@ -1913,6 +1923,7 @@ segments:
     type: code
     start: 0x331940
     vram: 0xE001E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, star]
   - name: effect_gfx_star
@@ -1942,6 +1953,7 @@ segments:
     type: code
     start: 0x333EC0
     vram: 0xE0020000
+    max_size: 0x1000
     subsegments:
     - [auto, c, emote]
   - name: effect_gfx_emote
@@ -1982,6 +1994,7 @@ segments:
     type: code
     start: 0x337240
     vram: 0xE0022000
+    max_size: 0x1000
     subsegments:
     - [auto, c, sparkles]
   - name: effect_gfx_sparkles
@@ -2020,6 +2033,7 @@ segments:
     type: code
     start: 0x339250
     vram: 0xE0024000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shape_spell]
   - name: effect_gfx_shape_spell
@@ -2050,6 +2064,7 @@ segments:
     type: code
     start: 0x33B180
     vram: 0xE0026000
+    max_size: 0x1000
     subsegments:
     - [auto, c, gather_energy_pink]
   - name: effect_gfx_gather_energy_pink
@@ -2079,6 +2094,7 @@ segments:
     type: code
     start: 0x33CDF0
     vram: 0xE0028000
+    max_size: 0x1000
     subsegments:
     - [auto, c, drop_leaves]
   - name: effect_gfx_drop_leaves
@@ -2107,6 +2123,7 @@ segments:
     type: code
     start: 0x33E8C0
     vram: 0xE002A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, dust]
   - name: effect_gfx_dust
@@ -2137,6 +2154,7 @@ segments:
     type: code
     start: 0x33FE80
     vram: 0xE002C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shattering_stones]
   - name: effect_gfx_shattering_stones
@@ -2177,6 +2195,7 @@ segments:
     type: code
     start: 0x3419E0
     vram: 0xE002E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, smoke_ring]
   - name: effect_damage_stars
@@ -2184,6 +2203,7 @@ segments:
     type: code
     start: 0x342140
     vram: 0xE0030000
+    max_size: 0x1000
     subsegments:
     - [auto, c, damage_stars]
   - name: effect_gfx_damage_stars
@@ -2212,6 +2232,7 @@ segments:
     type: code
     start: 0x343680
     vram: 0xE0032000
+    max_size: 0x1000
     subsegments:
     - [auto, c, explosion]
   - name: effect_gfx_explosion
@@ -2243,6 +2264,7 @@ segments:
     type: code
     start: 0x344A10
     vram: 0xE0034000
+    max_size: 0x1000
     subsegments:
     - [auto, c, lens_flare]
   - name: effect_gfx_lens_flare
@@ -2266,6 +2288,7 @@ segments:
     type: code
     start: 0x3454E0
     vram: 0xE0036000
+    max_size: 0x1000
     subsegments:
     - [auto, c, got_item_outline]
   - name: effect_gfx_got_item_outline
@@ -2300,6 +2323,7 @@ segments:
     type: code
     start: 0x34DD20
     vram: 0xE0038000
+    max_size: 0x1000
     subsegments:
     - [auto, c, spiky_white_aura]
   - name: effect_gfx_spiky_white_aura
@@ -2324,6 +2348,7 @@ segments:
     type: code
     start: 0x34EC80
     vram: 0xE003A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, smoke_impact]
   - name: effect_damage_indicator
@@ -2394,6 +2419,7 @@ segments:
     type: code
     start: 0x352440
     vram: 0xE003E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, purple_ring]
   - name: effect_gfx_purple_ring
@@ -2421,6 +2447,7 @@ segments:
     type: code
     start: 0x353300
     vram: 0xE0040000
+    max_size: 0x1000
     subsegments:
     - [auto, c, flame]
   - name: effect_gfx_flame
@@ -2449,6 +2476,7 @@ segments:
     type: code
     start: 0x3547A0
     vram: 0xE0042000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stars_burst]
   - name: effect_stars_shimmer
@@ -2456,6 +2484,7 @@ segments:
     type: code
     start: 0x354F60
     vram: 0xE0044000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stars_shimmer]
   - name: effect_rising_bubble
@@ -2463,6 +2492,7 @@ segments:
     type: code
     start: 0x355EE0
     vram: 0xE0046000
+    max_size: 0x1000
     subsegments:
     - [auto, c, rising_bubble]
   - name: effect_gfx_rising_bubble
@@ -2494,6 +2524,7 @@ segments:
     type: code
     start: 0x356980
     vram: 0xE0048000
+    max_size: 0x1000
     subsegments:
     - [auto, c, ring_blast]
   - name: effect_gfx_ring_blast
@@ -2518,6 +2549,7 @@ segments:
     type: code
     start: 0x3584C0
     vram: 0xE004A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shockwave]
   - name: effect_gfx_shockwave
@@ -2545,6 +2577,7 @@ segments:
     type: code
     start: 0x359F20
     vram: 0xE004C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, music_note]
   - name: effect_gfx_music_note
@@ -2587,6 +2620,7 @@ segments:
     type: code
     start: 0x35B9D0
     vram: 0xE004E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, smoke_burst]
   - name: effect_sweat
@@ -2594,6 +2628,7 @@ segments:
     type: code
     start: 0x35BFD0
     vram: 0xE0050000
+    max_size: 0x1000
     subsegments:
     - [auto, c, sweat]
   - name: effect_gfx_sweat
@@ -2621,6 +2656,7 @@ segments:
     type: code
     start: 0x35CA80
     vram: 0xE0052000
+    max_size: 0x1000
     subsegments:
     - [auto, c, sleep_bubble]
   - name: effect_gfx_sleep_bubble
@@ -2647,6 +2683,7 @@ segments:
     type: code
     start: 0x35DA00
     vram: 0xE0056000
+    max_size: 0x1000
     subsegments:
     - [auto, c, windy_leaves]
   - name: effect_falling_leaves
@@ -2654,6 +2691,7 @@ segments:
     type: code
     start: 0x35E920
     vram: 0xE0058000
+    max_size: 0x1000
     subsegments:
     - [auto, c, falling_leaves]
   - name: effect_gfx_falling_leaves
@@ -2678,6 +2716,7 @@ segments:
     type: code
     start: 0x3602C0
     vram: 0xE005A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stars_spread]
   - name: effect_gfx_stars_spread
@@ -2701,6 +2740,7 @@ segments:
     type: code
     start: 0x360F40
     vram: 0xE005C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, steam_burst]
   - name: effect_gfx_steam_burst
@@ -2724,6 +2764,7 @@ segments:
     type: code
     start: 0x3625C0
     vram: 0xE005E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stars_orbiting]
   - name: effect_gfx_stars_orbiting
@@ -2747,6 +2788,7 @@ segments:
     type: code
     start: 0x363160
     vram: 0xE0060000
+    max_size: 0x1000
     subsegments:
     - [auto, c, big_snowflakes]
   - name: effect_gfx_big_snowflakes
@@ -2774,6 +2816,7 @@ segments:
     type: code
     start: 0x364300
     vram: 0xE0062000
+    max_size: 0x1000
     subsegments:
     - [auto, c, debuff]
   - name: effect_gfx_debuff
@@ -2798,6 +2841,7 @@ segments:
     type: code
     start: 0x364F10
     vram: 0xE0064000
+    max_size: 0x1000
     subsegments:
     - [auto, c, green_impact]
   - name: effect_gfx_green_impact
@@ -2822,6 +2866,7 @@ segments:
     type: code
     start: 0x366030
     vram: 0xE0066000
+    max_size: 0x1000
     subsegments:
     - [auto, c, radial_shimmer]
   - name: effect_gfx_radial_shimmer
@@ -2863,6 +2908,7 @@ segments:
     type: code
     start: 0x36A8D0
     vram: 0xE0068000
+    max_size: 0x1000
     subsegments:
     - [auto, c, ending_decals]
   - name: effect_gfx_ending_decals
@@ -2897,6 +2943,7 @@ segments:
     type: code
     start: 0x36D020
     vram: 0xE006A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, light_rays]
   - name: effect_gfx_light_rays
@@ -2923,6 +2970,7 @@ segments:
     type: code
     start: 0x36E1D0
     vram: 0xE006C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, lightning]
   - name: effect_gfx_lightning
@@ -2981,6 +3029,7 @@ segments:
     type: code
     start: 0x372790
     vram: 0xE006E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, fire_breath]
   - name: effect_gfx_fire_breath
@@ -3011,6 +3060,7 @@ segments:
     type: code
     start: 0x3740B0
     vram: 0xE0070000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shimmer_burst]
   - name: effect_energy_shockwave
@@ -3018,6 +3068,7 @@ segments:
     type: code
     start: 0x374E50
     vram: 0xE0072000
+    max_size: 0x1000
     subsegments:
     - [auto, c, energy_shockwave]
   - name: effect_gfx_energy_shockwave
@@ -3044,6 +3095,7 @@ segments:
     type: code
     start: 0x376460
     vram: 0xE0074000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shimmer_wave]
   - name: effect_aura
@@ -3051,6 +3103,7 @@ segments:
     type: code
     start: 0x377070
     vram: 0xE0076000
+    max_size: 0x1000
     subsegments:
     - [auto, c, aura]
   - name: effect_gfx_aura
@@ -3094,6 +3147,7 @@ segments:
     type: code
     start: 0x37A3F0
     vram: 0xE0078000
+    max_size: 0x1000
     subsegments:
     - [auto, c, bulb_glow]
   - name: effect_gfx_bulb_glow
@@ -3122,6 +3176,7 @@ segments:
     type: code
     start: 0x37C540
     vram: 0xE007A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_3D]
   - name: effect_gfx_effect_3D
@@ -3146,6 +3201,7 @@ segments:
     type: code
     start: 0x37D490
     vram: 0xE007C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, blast]
   - name: effect_gfx_blast
@@ -3197,6 +3253,7 @@ segments:
     type: code
     start: 0x37F720
     vram: 0xE007E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, fire_flower]
   - name: effect_gfx_fire_flower
@@ -3234,6 +3291,7 @@ segments:
     type: code
     start: 0x3812C0
     vram: 0xE0080000
+    max_size: 0x1000
     subsegments:
     - [auto, c, recover]
   - name: effect_gfx_recover
@@ -3300,6 +3358,7 @@ segments:
     type: code
     start: 0x385640
     vram: 0xE0082000
+    max_size: 0x1000
     subsegments:
     - [auto, c, disable_x]
   - name: effect_gfx_disable_x
@@ -3355,6 +3414,7 @@ segments:
     type: code
     start: 0x3889D0
     vram: 0xE0084000
+    max_size: 0x1000
     subsegments:
     - [auto, c, bombette_breaking]
   - name: effect_firework
@@ -3362,6 +3422,7 @@ segments:
     type: code
     start: 0x389850
     vram: 0xE0086000
+    max_size: 0x1000
     subsegments:
     - [auto, c, firework]
   - name: effect_gfx_firework
@@ -3393,6 +3454,7 @@ segments:
     type: code
     start: 0x38ADF0
     vram: 0xE0088000
+    max_size: 0x1000
     subsegments:
     - [auto, c, confetti]
   - name: effect_gfx_confetti
@@ -3421,6 +3483,7 @@ segments:
     type: code
     start: 0x38C5F0
     vram: 0xE008A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, snowfall]
   - name: effect_gfx_snowfall
@@ -3450,6 +3513,7 @@ segments:
     type: code
     start: 0x38DE00
     vram: 0xE008C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_46]
   - name: effect_gfx_effect_46
@@ -3473,6 +3537,7 @@ segments:
     type: code
     start: 0x38EE60
     vram: 0xE008E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, gather_magic]
   - name: effect_gfx_gather_magic
@@ -3499,6 +3564,7 @@ segments:
     type: code
     start: 0x38F900
     vram: 0xE0090000
+    max_size: 0x1000
     subsegments:
     - [auto, c, attack_result_text]
   - name: effect_gfx_attack_result_text
@@ -3542,6 +3608,7 @@ segments:
     type: code
     start: 0x391D30
     vram: 0xE0092000
+    max_size: 0x1000
     subsegments:
     - [auto, c, small_gold_sparkle]
   - name: effect_gfx_small_gold_sparkle
@@ -3574,6 +3641,7 @@ segments:
     type: code
     start: 0x3928D0
     vram: 0xE0094000
+    max_size: 0x1000
     subsegments:
     - [auto, c, flashing_box_shockwave]
   - name: effect_gfx_flashing_box_shockwave
@@ -3607,6 +3675,7 @@ segments:
     type: code
     start: 0x394280
     vram: 0xE0096000
+    max_size: 0x1000
     subsegments:
     - [auto, c, balloon]
   - name: effect_gfx_balloon
@@ -3643,6 +3712,7 @@ segments:
     type: code
     start: 0x395BB0
     vram: 0xE0098000
+    max_size: 0x1000
     subsegments:
     - [auto, c, floating_rock]
   - name: effect_gfx_floating_rock
@@ -3670,6 +3740,7 @@ segments:
     type: code
     start: 0x3965B0
     vram: 0xE009A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, chomp_drop]
   - name: effect_gfx_chomp_drop
@@ -3695,6 +3766,7 @@ segments:
     type: code
     start: 0x3981F0
     vram: 0xE009C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, quizmo_stage]
   - name: effect_gfx_quizmo_stage
@@ -3791,6 +3863,7 @@ segments:
     type: code
     start: 0x39FF20
     vram: 0xE009E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, radiating_energy_orb]
   - name: effect_gfx_radiating_energy_orb
@@ -3824,6 +3897,7 @@ segments:
     type: code
     start: 0x3A2290
     vram: 0xE00A0000
+    max_size: 0x1000
     subsegments:
     - [auto, c, quizmo_answer]
   - name: effect_gfx_quizmo_answer
@@ -3847,6 +3921,7 @@ segments:
     type: code
     start: 0x3A2990
     vram: 0xE00A2000
+    max_size: 0x1000
     subsegments:
     - [auto, c, motion_blur_flame]
   - name: effect_gfx_motion_blur_flame
@@ -3872,6 +3947,7 @@ segments:
     type: code
     start: 0x3A37E0
     vram: 0xE00A4000
+    max_size: 0x1000
     subsegments:
     - [auto, c, energy_orb_wave]
   - name: effect_gfx_energy_orb_wave
@@ -3900,6 +3976,7 @@ segments:
     type: code
     start: 0x3A5550
     vram: 0xE00A6000
+    max_size: 0x1000
     subsegments:
     - [auto, c, merlin_house_stars]
   - name: effect_gfx_merlin_house_stars
@@ -3930,6 +4007,7 @@ segments:
     type: code
     start: 0x3A70F0
     vram: 0xE00A8000
+    max_size: 0x1000
     subsegments:
     - [auto, c, quizmo_audience]
   - name: effect_gfx_quizmo_audience
@@ -3990,6 +4068,7 @@ segments:
     type: code
     start: 0x3AA920
     vram: 0xE00AA000
+    max_size: 0x1000
     subsegments:
     - [auto, c, butterflies]
   - name: effect_gfx_butterflies
@@ -4046,6 +4125,7 @@ segments:
     type: code
     start: 0x3AEE20
     vram: 0xE00AC000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stat_change]
   - name: effect_gfx_stat_change
@@ -4103,6 +4183,7 @@ segments:
     type: code
     start: 0x3B2350
     vram: 0xE00AE000
+    max_size: 0x1000
     subsegments:
     - [auto, c, snaking_static]
   - name: effect_gfx_snaking_static
@@ -4127,6 +4208,7 @@ segments:
     type: code
     start: 0x3B3EB0
     vram: 0xE00B0000
+    max_size: 0x1000
     subsegments:
     - [auto, c, thunderbolt_ring]
   - name: effect_gfx_thunderbolt_ring
@@ -4149,6 +4231,7 @@ segments:
     type: code
     start: 0x3B4790
     vram: 0xE00B2000
+    max_size: 0x1000
     subsegments:
     - [auto, c, squirt]
   - name: effect_gfx_squirt
@@ -4174,6 +4257,7 @@ segments:
     type: code
     start: 0x3B5CF0
     vram: 0xE00B4000
+    max_size: 0x1000
     subsegments:
     - [auto, c, water_block]
   - name: effect_gfx_water_block
@@ -4203,6 +4287,7 @@ segments:
     type: code
     start: 0x3B7160
     vram: 0xE00B6000
+    max_size: 0x1000
     subsegments:
     - [auto, c, waterfall]
   - name: effect_gfx_waterfall
@@ -4225,6 +4310,7 @@ segments:
     type: code
     start: 0x3B7B80
     vram: 0xE00B8000
+    max_size: 0x1000
     subsegments:
     - [auto, c, water_fountain]
   - name: effect_gfx_water_fountain
@@ -4251,6 +4337,7 @@ segments:
     type: code
     start: 0x3B8BD0
     vram: 0xE00BA000
+    max_size: 0x1000
     subsegments:
     - [auto, c, underwater]
   - name: effect_gfx_underwater
@@ -4284,6 +4371,7 @@ segments:
     type: code
     start: 0x3BA030
     vram: 0xE00BC000
+    max_size: 0x1000
     subsegments:
     - [auto, c, lightning_bolt]
   - name: effect_gfx_lightning_bolt
@@ -4306,6 +4394,7 @@ segments:
     type: code
     start: 0x3BBF60
     vram: 0xE00BE000
+    max_size: 0x1000
     subsegments:
     - [auto, c, water_splash]
   - name: effect_gfx_water_splash
@@ -4334,6 +4423,7 @@ segments:
     type: code
     start: 0x3BCD60
     vram: 0xE00C0000
+    max_size: 0x1000
     subsegments:
     - [auto, c, snowman_doll]
   - name: effect_gfx_snowman_doll
@@ -4460,6 +4550,7 @@ segments:
     type: code
     start: 0x3C11D0
     vram: 0xE00C2000
+    max_size: 0x1000
     subsegments:
     - [auto, c, fright_jar]
   - name: effect_gfx_fright_jar
@@ -4490,6 +4581,7 @@ segments:
     type: code
     start: 0x3CADF0
     vram: 0xE00C4000
+    max_size: 0x1000
     subsegments:
     - [auto, c, stop_watch]
   - name: effect_gfx_stop_watch
@@ -4515,6 +4607,7 @@ segments:
     type: code
     start: 0x3CC9E0
     vram: 0xE00C6000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_63]
   - name: effect_gfx_effect_63
@@ -4554,6 +4647,7 @@ segments:
     type: code
     start: 0x3CF3A0
     vram: 0xE00C8000
+    max_size: 0x1000
     subsegments:
     - [auto, c, throw_spiny]
   - name: effect_gfx_throw_spiny
@@ -4583,6 +4677,7 @@ segments:
     type: code
     start: 0x3D0500
     vram: 0xE00CA000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_65]
   - name: effect_gfx_effect_65
@@ -4605,6 +4700,7 @@ segments:
     type: code
     start: 0x3D1690
     vram: 0xE00CC000
+    max_size: 0x1000
     subsegments:
     - [auto, c, tubba_heart_attack]
   - name: effect_gfx_tubba_heart_attack
@@ -4631,6 +4727,7 @@ segments:
     type: code
     start: 0x3D2AC0
     vram: 0xE00CE000
+    max_size: 0x1000
     subsegments:
     - [auto, c, whirlwind]
   - name: effect_gfx_whirlwind
@@ -4653,6 +4750,7 @@ segments:
     type: code
     start: 0x3D3E20
     vram: 0xE00D0000
+    max_size: 0x1000
     subsegments:
     - [auto, c, red_impact]
   - name: effect_floating_cloud_puff
@@ -4660,6 +4758,7 @@ segments:
     type: code
     start: 0x3D4970
     vram: 0xE00D2000
+    max_size: 0x1000
     subsegments:
     - [auto, c, floating_cloud_puff]
   - name: effect_gfx_floating_cloud_puff
@@ -4684,6 +4783,7 @@ segments:
     type: code
     start: 0x3D5020
     vram: 0xE00D6000
+    max_size: 0x1000
     subsegments:
     - [auto, c, energy_in_out]
   - name: effect_gfx_energy_in_out
@@ -4738,6 +4838,7 @@ segments:
     type: code
     start: 0x3D67C0
     vram: 0xE00D8000
+    max_size: 0x1000
     subsegments:
     - [auto, c, tattle_window]
   - name: effect_gfx_tattle_window
@@ -4758,6 +4859,7 @@ segments:
     type: code
     start: 0x3D7240
     vram: 0xE00DA000
+    max_size: 0x1000
     subsegments:
     - [auto, c, shiny_flare]
   - name: effect_gfx_shiny_flare
@@ -4781,6 +4883,7 @@ segments:
     type: code
     start: 0x3D7A70
     vram: 0xE00DC000
+    max_size: 0x1000
     subsegments:
     - [auto, c, huff_puff_breath]
   - name: effect_gfx_huff_puff_breath
@@ -4809,6 +4912,7 @@ segments:
     type: code
     start: 0x3D8720
     vram: 0xE00DE000
+    max_size: 0x1000
     subsegments:
     - [auto, c, cold_breath]
   - name: effect_gfx_cold_breath
@@ -4842,6 +4946,7 @@ segments:
     type: code
     start: 0x3DB460
     vram: 0xE00E0000
+    max_size: 0x1000
     subsegments:
     - [auto, c, embers]
   - name: effect_gfx_embers
@@ -4866,6 +4971,7 @@ segments:
     type: code
     start: 0x3DC310
     vram: 0xE00E2000
+    max_size: 0x1000
     subsegments:
     - [auto, c, hieroglyphs]
   - name: effect_gfx_hieroglyphs
@@ -4889,6 +4995,7 @@ segments:
     type: code
     start: 0x3DE000
     vram: 0xE00E4000
+    max_size: 0x1000
     subsegments:
     - [auto, c, misc_particles]
   - name: effect_gfx_misc_particles
@@ -4926,6 +5033,7 @@ segments:
     type: code
     start: 0x3E0930
     vram: 0xE00E6000
+    max_size: 0x1000
     subsegments:
     - [auto, c, static_status]
   - name: effect_gfx_static_status
@@ -4951,6 +5059,7 @@ segments:
     type: code
     start: 0x3E1690
     vram: 0xE00E8000
+    max_size: 0x1000
     subsegments:
     - [auto, c, moving_cloud]
   - name: effect_gfx_moving_cloud
@@ -4975,6 +5084,7 @@ segments:
     type: code
     start: 0x3E1EE0
     vram: 0xE00EA000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_75]
   - name: effect_gfx_effect_75
@@ -5010,6 +5120,7 @@ segments:
     type: code
     start: 0x3E43A0
     vram: 0xE010A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, firework_rocket]
   - name: effect_gfx_firework_rocket
@@ -5033,6 +5144,7 @@ segments:
     type: code
     start: 0x3E54C0
     vram: 0xE010C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, peach_star_beam]
   - name: effect_gfx_peach_star_beam
@@ -5107,6 +5219,7 @@ segments:
     type: code
     start: 0x3EB4E0
     vram: 0xE010E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, chapter_change]
   - name: effect_gfx_chapter_change
@@ -5161,6 +5274,7 @@ segments:
     type: code
     start: 0x3F83F0
     vram: 0xE0110000
+    max_size: 0x1000
     subsegments:
     - [auto, c, ice_shard]
   - name: effect_gfx_ice_shard
@@ -5186,6 +5300,7 @@ segments:
     type: code
     start: 0x3F9E50
     vram: 0xE0112000
+    max_size: 0x1000
     subsegments:
     - [auto, c, spirit_card]
   - name: effect_gfx_spirit_card # effect spirit_card, something_rotating gfx
@@ -5256,6 +5371,7 @@ segments:
     type: code
     start: 0x3FEAE0
     vram: 0xE0114000
+    max_size: 0x1000
     subsegments:
     - [auto, c, lil_oink]
   - name: effect_gfx_lil_oink
@@ -5380,6 +5496,7 @@ segments:
     type: code
     start: 0x402640
     vram: 0xE0116000
+    max_size: 0x1000
     subsegments:
     - [auto, c, something_rotating]
   - name: effect_breaking_junk
@@ -5387,6 +5504,7 @@ segments:
     type: code
     start: 0x403400
     vram: 0xE0118000
+    max_size: 0x1000
     subsegments:
     - [auto, c, breaking_junk]
   - name: effect_gfx_breaking_junk
@@ -5420,6 +5538,7 @@ segments:
     type: code
     start: 0x404220
     vram: 0xE011A000
+    max_size: 0x1000
     subsegments:
     - [auto, c, partner_buff]
   - name: effect_gfx_partner_buff
@@ -5462,6 +5581,7 @@ segments:
     type: code
     start: 0x406B40
     vram: 0xE011C000
+    max_size: 0x1000
     subsegments:
     - [auto, c, quizmo_assistant]
   - name: effect_gfx_quizmo_assistant
@@ -5503,6 +5623,7 @@ segments:
     type: code
     start: 0x409990
     vram: 0xE011E000
+    max_size: 0x1000
     subsegments:
     - [auto, c, ice_pillar]
   - name: effect_gfx_ice_pillar
@@ -5537,6 +5658,7 @@ segments:
     type: code
     start: 0x40B3F0
     vram: 0xE0120000
+    max_size: 0x1000
     subsegments:
     - [auto, c, sun]
   - name: effect_gfx_sun
@@ -5578,6 +5700,7 @@ segments:
     type: code
     start: 0x40C5A0
     vram: 0xE0122000
+    max_size: 0x1000
     subsegments:
     - [auto, c, star_spirits_energy]
   - name: effect_gfx_star_spirits_energy
@@ -5623,6 +5746,7 @@ segments:
     type: code
     start: 0x412730
     vram: 0xE0124000
+    max_size: 0x1000
     subsegments:
     - [auto, c, pink_sparkles]
   - name: effect_star_outline
@@ -5630,6 +5754,7 @@ segments:
     type: code
     start: 0x413360
     vram: 0xE0126000
+    max_size: 0x1000
     subsegments:
     - [auto, c, star_outline]
   - name: effect_gfx_star_outline
@@ -5655,6 +5780,7 @@ segments:
     type: code
     start: 0x414BA0
     vram: 0xE0128000
+    max_size: 0x1000
     subsegments:
     - [auto, c, effect_86]
   - name: effect_gfx_effect_86


### PR DESCRIPTION
Adds a `max_size` field that can be added to any segment in `splat.yaml`