### PR TITLE
Fix debug banner info

### DIFF
--- a/src/battle/btl_states_actions.c
+++ b/src/battle/btl_states_actions.c
@@ -6,6 +6,7 @@
 #include "battle/battle.h"
 #include "model.h"
 #include "game_modes.h"
+#include "dx/debug_menu.h"
 
 #if VERSION_JP
 extern Addr btl_states_menus_ROM_START;

--- a/src/dx/debug_menu.c
+++ b/src/dx/debug_menu.c
@@ -1919,7 +1919,7 @@ void dx_debug_update_banner() {
     char fmtBuf[128];
     s32 effect;
 
-    if (gGameStatus.context == CONTEXT_BATTLE) {
+    if (gGameStatus.context == CONTEXT_WORLD) {
         sprintf(fmtBuf, "Map: %7s (%X)", LastMapName, LastMapEntry);
         dx_debug_draw_ascii(fmtBuf, DefaultColor, 220, BottomRowY);
 


### PR DESCRIPTION
The recent `isBattle` refactor broke the debug banner information. This fixes it.