### PR TITLE
C++ support

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -8,6 +8,10 @@
 #include "stdlib/stdarg.h"
 #include "libc/xstdio.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 f32 fabsf(f32 f);
 f64 fabs(f64 f);
 f32 cosine(s16 arg0);
@@ -1095,5 +1099,9 @@ void update_item_entities(void);
 void restore_map_collision_data(void);
 void mdl_load_all_textures(struct ModelNode* model, s32 romOffset, s32 size);
 void mdl_calculate_model_sizes(void);
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -22,8 +22,14 @@
 
 #define NAME_SUFFIX
 #define NAME_PREFIX
+#ifdef _LANGUAGE_C_PLUS_PLUS
+// use C++ namespaces instead of these macros!
+#define A(sym) sym
+#define N(sym) sym
+#else
 #define A(sym) NS(AREA, NAME_PREFIX, sym, NAME_SUFFIX)
 #define N(sym) NS(NAMESPACE, NAME_PREFIX, sym, NAME_SUFFIX)
+#endif
 
 #define ARRAY_COUNT(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
 

--- a/include/npc.h
+++ b/include/npc.h
@@ -5,6 +5,10 @@
 #include "enums.h"
 #include "script_api/map.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 // battle and stage are optional in overloaded NPC_GROUP macros
 #define NPC_GROUP(args...) VFUNC(NPC_GROUP, args)
 #define NPC_GROUP1(npcs)                { sizeof(npcs) / sizeof(NpcData), (NpcData*) &npcs, 0, 0 }
@@ -656,5 +660,9 @@ Enemy* get_enemy(s32 npcID);
 Enemy* get_enemy_safe(s32 npcID);
 
 void set_npc_sprite(Npc* npc, s32 anim, AnimID* extraAnimList);
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/include/script_api/battle.h
+++ b/include/script_api/battle.h
@@ -9,6 +9,10 @@
 
 #include "effects.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 API_CALLABLE(EnablePartnerBlur);
 API_CALLABLE(DisablePartnerBlur);
 API_CALLABLE(UseBattleCamPreset);
@@ -377,5 +381,9 @@ extern EvtScript Rumble_Unused_1;
 extern EvtScript Rumble_Unused_2;
 extern EvtScript Rumble_Unused_3;
 extern EvtScript Rumble_Unused_4;
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/include/script_api/common.h
+++ b/include/script_api/common.h
@@ -11,6 +11,10 @@
 #include "../common.h"
 #include "macros.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 /// @{
 /// @name Map
 
@@ -1372,5 +1376,9 @@ API_CALLABLE(DemoJoystickXY);
 
 extern EvtScript EnemyNpcHit;
 extern EvtScript EnemyNpcDefeat;
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/include/script_api/macros.h
+++ b/include/script_api/macros.h
@@ -4,6 +4,10 @@
 #include "evt.h"
 #include "stdlib/stdarg.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 /****** EXPRESSIONS ***************************************************************************************************/
 
 /// Expressions in EVT instructions should be one of the following types:
@@ -829,5 +833,9 @@
     Call(PlayEffect_impl, effect, subtype, a, b, c, d, e, f, g, h, i, j, k, 0)
 #define PlayEffect14(effect, subtype, a, b, c, d, e, f, g, h, i, j, k, l) \
     Call(PlayEffect_impl, effect, subtype, a, b, c, d, e, f, g, h, i, j, k, l)
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/include/script_api/map.h
+++ b/include/script_api/map.h
@@ -6,6 +6,10 @@
 
 #include "script_api/common.h"
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 API_CALLABLE(MakeNpcs);
 API_CALLABLE(BasicAI_Main);
 API_CALLABLE(ResetFromLava);
@@ -55,5 +59,9 @@ extern EvtScript BaseExitDoor;
 extern EvtScript BaseEnterDoor;
 extern EvtScript EnterPostPipe;
 extern EvtScript EVS_ShopOwnerDialog;
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/src/dx/debug_menu.h
+++ b/src/dx/debug_menu.h
@@ -2,6 +2,10 @@
 #include "dx/config.h"
 #if DX_DEBUG_MENU || defined(DX_QUICK_LAUNCH_BATTLE)
 
+#ifdef _LANGUAGE_C_PLUS_PLUS
+extern "C" {
+#endif
+
 #define DX_DEBUG_DUMMY_ID 0xDEAD
 
 typedef enum DebugCheat {
@@ -24,6 +28,8 @@ void dx_debug_set_map_info(char* mapName, s32 entryID);
 void dx_debug_set_battle_info(s32 battleID, char* stageName);
 
 void dx_debug_begin_battle_with_IDs(s16 battle, s16 stage);
+
+void dx_hashed_debug_printf(char* filename, s32 line, char* fmt, ...);
 
 #define debug_print(text) dx_hashed_debug_printf(__FILE__,__LINE__,text)
 #define debug_printf(fmt, args...) dx_hashed_debug_printf(__FILE__,__LINE__,fmt,##args)
@@ -67,5 +73,9 @@ API_CALLABLE(_dxDebugFloatPrintf);
     Call(_dxDebugFloatPrintf, Ref(__FILE__), __LINE__, Ref(text), a, b, c, d, e, f, 0)
 #define DebugFloatPrintf8(text, a, b, c, d, e, f, g) \
     Call(_dxDebugFloatPrintf, Ref(__FILE__), __LINE__, Ref(text), a, b, c, d, e, f, g)
+
+#ifdef _LANGUAGE_C_PLUS_PLUS
+}
+#endif
 
 #endif

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -552,7 +552,7 @@ class Configure:
                 implicit = []
                 order_only = []
 
-                if task in ["cc", "cxx", "cc_modern"]:
+                if task in ["cc", "cxx", "cc_modern", "cxx_modern"]:
                     order_only.append("generated_code_" + self.version)
                     order_only.append("inc_img_bins_" + self.version)
                     if task == "cc_modern" and object_paths[0].suffixes[-1] != ".gch":


### PR DESCRIPTION
Adds `extern "C"` to headers so that they can be used in C++ files (`cpp` splat segment type).

e.g.
![image](https://github.com/user-attachments/assets/9ebcdb66-0fbf-4724-aef5-f16e831ab9d7)
