### PR TITLE
upload clangd index to CI and download in configure

### DIFF
--- a/.github/workflows/release-dx.yaml
+++ b/.github/workflows/release-dx.yaml
@@ -36,6 +36,26 @@ jobs:
         uses: MariachiBear/get-repo-name-action@v1.1.0
         with:
           string-case: paramCase
+      - name: Build clangd index
+        run: |
+          nix develop --command bash -c '
+            ./configure
+            ninja -t compdb > compile_commands.json
+          '
+
+          TAG=$(curl -s https://api.github.com/repos/clangd/clangd/releases/latest | jq -r .tag_name)
+          curl -L -o clangd_indexing_tools.zip \
+            "https://github.com/clangd/clangd/releases/download/$TAG/clangd_indexing_tools-linux-$TAG.zip"
+          unzip clangd_indexing_tools.zip
+          INDEXER=$(find . -name 'clangd-indexer' -type f)
+          chmod +x "$INDEXER"
+
+          # Build index in YAML format so we can make paths portable
+          "$INDEXER" --format=yaml --executor=all-TUs compile_commands.json > papermario-dx.yaml
+
+          # Replace absolute CI paths with $$ROOT$$ placeholder
+          sed -i "s|$(pwd)/|\\$\\$ROOT\\$\\$/|g" papermario-dx.yaml
+          mv papermario-dx.yaml papermario-dx.idx
       - name: Copy patch file
         run: cp result/papermario.bps ${{ steps.repo-name.outputs.repository-name }}.bps
       - uses: softprops/action-gh-release@v2
@@ -43,3 +63,4 @@ jobs:
           files: |
             ${{ steps.repo-name.outputs.repository-name }}.bps
             result-toolchain/papermario-dx-windows.zip
+            papermario-dx.idx

--- a/.github/workflows/release-dx.yaml
+++ b/.github/workflows/release-dx.yaml
@@ -37,25 +37,7 @@ jobs:
         with:
           string-case: paramCase
       - name: Build clangd index
-        run: |
-          nix develop --command bash -c '
-            ./configure
-            ninja -t compdb > compile_commands.json
-          '
-
-          TAG=$(curl -s https://api.github.com/repos/clangd/clangd/releases/latest | jq -r .tag_name)
-          curl -L -o clangd_indexing_tools.zip \
-            "https://github.com/clangd/clangd/releases/download/$TAG/clangd_indexing_tools-linux-$TAG.zip"
-          unzip clangd_indexing_tools.zip
-          INDEXER=$(find . -name 'clangd-indexer' -type f)
-          chmod +x "$INDEXER"
-
-          # Build index in YAML format so we can make paths portable
-          "$INDEXER" --format=yaml --executor=all-TUs compile_commands.json > papermario-dx.yaml
-
-          # Replace absolute CI paths with $$ROOT$$ placeholder
-          sed -i "s|$(pwd)/|\\$\\$ROOT\\$\\$/|g" papermario-dx.yaml
-          mv papermario-dx.yaml papermario-dx.idx
+        run: nix build .#clangd-index --out-link result-clangd-index
       - name: Copy patch file
         run: cp result/papermario.bps ${{ steps.repo-name.outputs.repository-name }}.bps
       - uses: softprops/action-gh-release@v2
@@ -63,4 +45,4 @@ jobs:
           files: |
             ${{ steps.repo-name.outputs.repository-name }}.bps
             result-toolchain/papermario-dx-windows.zip
-            papermario-dx.idx
+            result-clangd-index/papermario-dx.idx

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -34,32 +34,13 @@ jobs:
       - name: Build Windows toolchain
         run: nix build .#windows-toolchain --out-link result-toolchain
       - name: Build clangd index
-        run: |
-          nix develop --command bash -c '
-            ./configure
-            ninja -t compdb > compile_commands.json
-          '
-
-          # Fetch clangd-indexer
-          TAG=$(curl -s https://api.github.com/repos/clangd/clangd/releases/latest | jq -r .tag_name)
-          curl -L -o clangd_indexing_tools.zip \
-            "https://github.com/clangd/clangd/releases/download/$TAG/clangd_indexing_tools-linux-$TAG.zip"
-          unzip clangd_indexing_tools.zip
-          INDEXER=$(find . -name 'clangd-indexer' -type f)
-          chmod +x "$INDEXER"
-
-          # Build index in YAML format so we can make paths portable
-          "$INDEXER" --format=yaml --executor=all-TUs compile_commands.json > papermario-dx.yaml
-
-          # Replace absolute CI paths with $$ROOT$$ placeholder
-          sed -i "s|$(pwd)/|\\$\\$ROOT\\$\\$/|g" papermario-dx.yaml
-          mv papermario-dx.yaml papermario-dx.idx
+        run: nix build .#clangd-index --out-link result-clangd-index
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: dx-nightly
           files: |
             result-toolchain/papermario-dx-windows.zip
-            papermario-dx.idx
+            result-clangd-index/papermario-dx.idx
       - name: Notify docs repo
         run: |
           gh api repos/star-haven/docs/dispatches \

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
@@ -24,12 +25,41 @@ jobs:
         with:
           name: papermario-dx
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Download base ROM
+        run: |
+          curl -L $BASEROM_US_URL -o papermario.us.z64
+          nix-store --add-fixed sha256 papermario.us.z64
+        env:
+          BASEROM_US_URL: ${{ secrets.BASEROM_US_URL }}
       - name: Build Windows toolchain
         run: nix build .#windows-toolchain --out-link result-toolchain
+      - name: Build clangd index
+        run: |
+          nix develop --command bash -c '
+            ./configure
+            ninja -t compdb > compile_commands.json
+          '
+
+          # Fetch clangd-indexer
+          TAG=$(curl -s https://api.github.com/repos/clangd/clangd/releases/latest | jq -r .tag_name)
+          curl -L -o clangd_indexing_tools.zip \
+            "https://github.com/clangd/clangd/releases/download/$TAG/clangd_indexing_tools-linux-$TAG.zip"
+          unzip clangd_indexing_tools.zip
+          INDEXER=$(find . -name 'clangd-indexer' -type f)
+          chmod +x "$INDEXER"
+
+          # Build index in YAML format so we can make paths portable
+          "$INDEXER" --format=yaml --executor=all-TUs compile_commands.json > papermario-dx.yaml
+
+          # Replace absolute CI paths with $$ROOT$$ placeholder
+          sed -i "s|$(pwd)/|\\$\\$ROOT\\$\\$/|g" papermario-dx.yaml
+          mv papermario-dx.yaml papermario-dx.idx
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: dx-nightly
-          files: result-toolchain/papermario-dx-windows.zip
+          files: |
+            result-toolchain/papermario-dx-windows.zip
+            papermario-dx.idx
       - name: Notify docs repo
         run: |
           gh api repos/star-haven/docs/dispatches \

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ ctx.c.m2c
 /data2c
 .nix-profile*
 /result
-/papermario-dx-windows/
 
 # Build artifacts
 build.ninja

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ build/
 .cache/clangd/
 # compile_commands.json requires hardcoded paths, so it can't be committed
 compile_commands.json
+# DX ephemeral data (clangd index, configure cache, etc.)
+/.dx/

--- a/build.bat
+++ b/build.bat
@@ -2,8 +2,12 @@
 setlocal enabledelayedexpansion
 
 set "REPO=bates64/papermario-dx"
-set "TOOLCHAIN_DIR=%~dp0papermario-dx-windows"
-set "TOOLCHAIN_ZIP=%~dp0papermario-dx-windows.zip"
+set "DX_DIR=%~dp0.dx"
+set "TOOLCHAIN_DIR=%DX_DIR%\windows"
+set "TOOLCHAIN_ZIP=%DX_DIR%\papermario-dx-windows.zip"
+
+:: Ensure .dx directory exists
+if not exist "%DX_DIR%" mkdir "%DX_DIR%"
 
 :: Check for git
 where git >nul 2>nul
@@ -30,8 +34,8 @@ del "%TEMP%\dx-tag-hash.txt" 2>nul
 :: Check if toolchain needs downloading
 set "NEED_DOWNLOAD=0"
 if not exist "%TOOLCHAIN_DIR%\bin\ninja.exe" set "NEED_DOWNLOAD=1"
-if exist "%TOOLCHAIN_DIR%\.tag" (
-    set /p CURRENT_TAG=<"%TOOLCHAIN_DIR%\.tag"
+if exist "%DX_DIR%\windows-tag" (
+    set /p CURRENT_TAG=<"%DX_DIR%\windows-tag"
     if not "!CURRENT_TAG!"=="%TAG_HASH%" set "NEED_DOWNLOAD=1"
 ) else (
     if exist "%TOOLCHAIN_DIR%" set "NEED_DOWNLOAD=1"
@@ -52,17 +56,18 @@ if "%NEED_DOWNLOAD%"=="1" (
         exit /b 1
     )
 
-    :: Extract
+    :: Extract (zip contains papermario-dx-windows/ dir, rename to .dx/windows/)
     echo Extracting toolchain...
-    tar -xf "%TOOLCHAIN_ZIP%" -C "%~dp0."
+    tar -xf "%TOOLCHAIN_ZIP%" -C "%DX_DIR%"
     if errorlevel 1 (
         echo Error: failed to extract toolchain.
         exit /b 1
     )
+    ren "%DX_DIR%\papermario-dx-windows" windows
     del "%TOOLCHAIN_ZIP%"
 
     :: Record the tag commit hash so we can detect updates (including force-moved tags)
-    echo %TAG_HASH%> "%TOOLCHAIN_DIR%\.tag"
+    echo %TAG_HASH%> "%DX_DIR%\windows-tag"
 )
 
 :: Set up PATH

--- a/flake.nix
+++ b/flake.nix
@@ -115,12 +115,62 @@
           ${pkgs.lib.optionalString pkgs.stdenv.isLinux
             "flips --create --bps ${baseRom} ver/us/build/papermario.z64 $out/papermario.bps"}
         '';
+
+        clangdIndexingTools = pkgs.callPackage ./tools/clangd-indexing-tools.nix {};
+        clangdIndex = pkgs.runCommand "papermario-dx-clangd-index" {
+          nativeBuildInputs = [
+            pkgsCross.stdenv.cc
+            binutils2_39
+            pkgs.python3
+            pkgs.python3Packages.pip
+            pkgs.python3Packages.virtualenv
+            pkgs.ninja
+            pkgs.gcc
+            pkgs.git
+            pkgs.libyaml
+            pkgs.iconv
+            (pkgs.callPackage ./tools/pigment64.nix {})
+            (pkgs.callPackage ./tools/crunch64.nix {})
+            clangdIndexingTools
+          ];
+          NIX_HARDENING_ENABLE = "";
+        } ''
+          cp -r --no-preserve=mode ${self} build
+          chmod -R u+w build
+          find build -name '*.py' -exec chmod +x {} +
+          cd build
+          git init --quiet
+          cp ${baseRom} ver/us/baserom.z64
+          patchShebangs --build tools/
+
+          virtualenv venv --quiet
+          source venv/bin/activate
+          pip install --no-index --find-links=${pythonDeps} -r requirements.txt --quiet
+
+          export PAPERMARIO_LD="${binutils2_39}/bin/mips-linux-gnu-ld"
+          python3 tools/build/configure.py --no-ccache
+          ninja
+
+          # Build binary RIFF index with a known path prefix.
+          # configure.py uses rewrite_index_paths.py to replace it with
+          # the local project root at download time.
+          clangd-indexer --executor=all-TUs compile_commands.json > papermario-dx.idx
+
+          # Rewrite paths in the RIFF string table
+          python3 tools/build/rewrite_index_paths.py papermario-dx.idx \
+            "$(pwd)/" '$$ROOT$$/'
+
+          mkdir -p $out
+          mv papermario-dx.idx $out/papermario-dx.idx
+        '';
+
       in {
         packages = {
           default = linuxRom;
         } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
           windows-toolchain = windowsToolchain;
           windows-rom = windowsToolchain.passthru.wineRom;
+          clangd-index = clangdIndex;
         };
 
         checks = pkgs.lib.optionalAttrs (system == "x86_64-linux") {

--- a/tools/build/clangd_index.py
+++ b/tools/build/clangd_index.py
@@ -1,0 +1,95 @@
+"""Download and configure a pre-built clangd index from GitHub releases."""
+
+import subprocess
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from rewrite_index_paths import rewrite_paths
+
+
+def exec_shell(command):
+    ret = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return ret.stdout
+
+
+def fetch_clangd_index(root: Path):
+    """Fetch the clangd index for the nearest dx-* tag and configure .clangd."""
+    tag = exec_shell(["git", "describe", "--tags", "--abbrev=0", "--match", "dx-*"]).strip()
+    if not tag:
+        return
+
+    dx_dir = root / ".dx"
+    dx_dir.mkdir(exist_ok=True)
+    idx_path = dx_dir / "papermario-dx.idx"
+    tag_hash = exec_shell(["git", "rev-parse", f"{tag}^{{}}"]).strip()
+    tag_file = dx_dir / "configure-tag"
+
+    # Check if we already have the index for this tag
+    need_download = True
+    if idx_path.exists() and tag_file.exists():
+        current_tag = tag_file.read_text().strip()
+        if current_tag == tag_hash:
+            need_download = False
+
+    if need_download:
+        repo = "bates64/papermario-dx"
+        url = f"https://github.com/{repo}/releases/download/{tag}/papermario-dx.idx"
+        print(f"configure: downloading clangd index for {tag}...")
+        try:
+            urllib.request.urlretrieve(url, str(idx_path))
+            # Rewrite $$ROOT$$ paths in the RIFF string table
+            abs_root = str(root.resolve())
+            idx_bytes = idx_path.read_bytes()
+            idx_bytes = rewrite_paths(
+                idx_bytes,
+                b"$$ROOT$$",
+                abs_root.encode(),
+            )
+            idx_path.write_bytes(idx_bytes)
+            tag_file.write_text(tag_hash + "\n")
+            print("configure: clangd index downloaded")
+        except urllib.error.HTTPError as e:
+            print(f"configure: clangd index not available for {tag} ({e.code}), skipping")
+        except Exception as e:
+            print(f"configure: failed to download clangd index: {e}")
+
+    # Update .clangd config with index path
+    if idx_path.exists():
+        _update_clangd_config(root, idx_path)
+
+
+def _update_clangd_config(root: Path, idx_path: Path):
+    """Add or update the Index.External section in .clangd."""
+    clangd_path = root / ".clangd"
+    abs_idx = str(idx_path.resolve())
+    abs_root = str(root.resolve()) + "/"
+
+    # Read existing config, preserving other sections
+    existing_lines = []
+    if clangd_path.exists():
+        with open(clangd_path) as f:
+            existing_lines = f.readlines()
+
+    # Remove any existing Index section
+    filtered = []
+    in_index = False
+    for line in existing_lines:
+        if line.rstrip() == "Index:":
+            in_index = True
+            continue
+        if in_index and (line.startswith("  ") or line.startswith("\t")):
+            continue
+        in_index = False
+        filtered.append(line)
+
+    # Append Index.External section
+    if filtered and not filtered[-1].endswith("\n"):
+        filtered.append("\n")
+    filtered.append("Index:\n")
+    filtered.append("  External:\n")
+    filtered.append(f"    File: {abs_idx}\n")
+    filtered.append(f"    MountPoint: {abs_root}\n")
+
+    with open(clangd_path, "w") as f:
+        f.writelines(filtered)

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -1453,6 +1453,82 @@ if __name__ == "__main__":
     ninja.build("all", "phony", all_rom_oks)
     ninja.default("all")
 
+    # Fetch pre-built clangd index from the matching dx-* GitHub release.
+    # This gives clangd project-wide symbols without needing a full background index.
+    try:
+        import urllib.request
+        import urllib.error
+
+        tag = exec_shell(["git", "describe", "--tags", "--abbrev=0", "--match", "dx-*"]).strip()
+        if tag:
+            dx_dir = ROOT / ".dx"
+            dx_dir.mkdir(exist_ok=True)
+            idx_path = dx_dir / "papermario-dx.idx"
+            tag_hash = exec_shell(["git", "rev-parse", f"{tag}^{{}}"]).strip()
+            tag_file = dx_dir / "configure-tag"
+
+            # Check if we already have the index for this tag
+            need_download = True
+            if idx_path.exists() and tag_file.exists():
+                current_tag = tag_file.read_text().strip()
+                if current_tag == tag_hash:
+                    need_download = False
+
+            if need_download:
+                repo = "bates64/papermario-dx"
+                url = f"https://github.com/{repo}/releases/download/{tag}/papermario-dx.idx"
+                print(f"configure: downloading clangd index for {tag}...")
+                try:
+                    urllib.request.urlretrieve(url, str(idx_path))
+                    # Replace $$ROOT$$ placeholder with local project root
+                    abs_root = str(ROOT.resolve())
+                    idx_content = idx_path.read_text()
+                    idx_content = idx_content.replace("$$ROOT$$", abs_root)
+                    idx_path.write_text(idx_content)
+                    tag_file.write_text(tag_hash + "\n")
+                    print("configure: clangd index downloaded")
+                except urllib.error.HTTPError as e:
+                    print(f"configure: clangd index not available for {tag} ({e.code}), skipping")
+                except Exception as e:
+                    print(f"configure: failed to download clangd index: {e}")
+
+            # Update .clangd config with index path
+            if idx_path.exists():
+                clangd_path = ROOT / ".clangd"
+                abs_idx = str(idx_path.resolve())
+                abs_root = str(ROOT.resolve()) + "/"
+
+                # Read existing config, preserving other sections
+                existing_lines = []
+                if clangd_path.exists():
+                    with open(clangd_path) as f:
+                        existing_lines = f.readlines()
+
+                # Remove any existing Index section
+                filtered = []
+                in_index = False
+                for line in existing_lines:
+                    if line.rstrip() == "Index:":
+                        in_index = True
+                        continue
+                    if in_index and (line.startswith("  ") or line.startswith("\t")):
+                        continue
+                    in_index = False
+                    filtered.append(line)
+
+                # Append Index.External section
+                if filtered and not filtered[-1].endswith("\n"):
+                    filtered.append("\n")
+                filtered.append("Index:\n")
+                filtered.append("  External:\n")
+                filtered.append(f"    File: {abs_idx}\n")
+                filtered.append(f"    MountPoint: {abs_root}\n")
+
+                with open(clangd_path, "w") as f:
+                    f.writelines(filtered)
+    except Exception:
+        pass
+
     # Generate compile_commands.json with MIPS cross-compiler flags stripped,
     # so clangd and clang-tidy can parse the compile commands.
     ninja.close()

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -1454,78 +1454,9 @@ if __name__ == "__main__":
     ninja.default("all")
 
     # Fetch pre-built clangd index from the matching dx-* GitHub release.
-    # This gives clangd project-wide symbols without needing a full background index.
     try:
-        import urllib.request
-        import urllib.error
-
-        tag = exec_shell(["git", "describe", "--tags", "--abbrev=0", "--match", "dx-*"]).strip()
-        if tag:
-            dx_dir = ROOT / ".dx"
-            dx_dir.mkdir(exist_ok=True)
-            idx_path = dx_dir / "papermario-dx.idx"
-            tag_hash = exec_shell(["git", "rev-parse", f"{tag}^{{}}"]).strip()
-            tag_file = dx_dir / "configure-tag"
-
-            # Check if we already have the index for this tag
-            need_download = True
-            if idx_path.exists() and tag_file.exists():
-                current_tag = tag_file.read_text().strip()
-                if current_tag == tag_hash:
-                    need_download = False
-
-            if need_download:
-                repo = "bates64/papermario-dx"
-                url = f"https://github.com/{repo}/releases/download/{tag}/papermario-dx.idx"
-                print(f"configure: downloading clangd index for {tag}...")
-                try:
-                    urllib.request.urlretrieve(url, str(idx_path))
-                    # Replace $$ROOT$$ placeholder with local project root
-                    abs_root = str(ROOT.resolve())
-                    idx_content = idx_path.read_text()
-                    idx_content = idx_content.replace("$$ROOT$$", abs_root)
-                    idx_path.write_text(idx_content)
-                    tag_file.write_text(tag_hash + "\n")
-                    print("configure: clangd index downloaded")
-                except urllib.error.HTTPError as e:
-                    print(f"configure: clangd index not available for {tag} ({e.code}), skipping")
-                except Exception as e:
-                    print(f"configure: failed to download clangd index: {e}")
-
-            # Update .clangd config with index path
-            if idx_path.exists():
-                clangd_path = ROOT / ".clangd"
-                abs_idx = str(idx_path.resolve())
-                abs_root = str(ROOT.resolve()) + "/"
-
-                # Read existing config, preserving other sections
-                existing_lines = []
-                if clangd_path.exists():
-                    with open(clangd_path) as f:
-                        existing_lines = f.readlines()
-
-                # Remove any existing Index section
-                filtered = []
-                in_index = False
-                for line in existing_lines:
-                    if line.rstrip() == "Index:":
-                        in_index = True
-                        continue
-                    if in_index and (line.startswith("  ") or line.startswith("\t")):
-                        continue
-                    in_index = False
-                    filtered.append(line)
-
-                # Append Index.External section
-                if filtered and not filtered[-1].endswith("\n"):
-                    filtered.append("\n")
-                filtered.append("Index:\n")
-                filtered.append("  External:\n")
-                filtered.append(f"    File: {abs_idx}\n")
-                filtered.append(f"    MountPoint: {abs_root}\n")
-
-                with open(clangd_path, "w") as f:
-                    f.writelines(filtered)
+        from clangd_index import fetch_clangd_index
+        fetch_clangd_index(ROOT)
     except Exception:
         pass
 

--- a/tools/build/rewrite_index_paths.py
+++ b/tools/build/rewrite_index_paths.py
@@ -1,0 +1,94 @@
+"""Rewrite file paths in a clangd RIFF index file.
+
+The RIFF index stores all strings (including file URIs) in a zlib-compressed
+string table. This script decompresses it, performs a find-and-replace on
+the raw strings, then recompresses and patches the RIFF chunk in-place.
+"""
+
+import struct
+import sys
+import zlib
+
+
+def rewrite_paths(data: bytes, old_prefix: bytes, new_prefix: bytes) -> bytes:
+    """Rewrite paths in a clangd RIFF (.idx) index."""
+    # RIFF header: "RIFF" <size:u32-le> <type:4bytes>
+    assert data[:4] == b"RIFF", "not a RIFF file"
+    riff_type = data[8:12]
+    assert riff_type == b"CdIx", f"unexpected RIFF type: {riff_type}"
+
+    pos = 12
+    chunks = []
+
+    while pos < len(data):
+        chunk_id = data[pos : pos + 4]
+        chunk_size = struct.unpack_from("<I", data, pos + 4)[0]
+        chunk_data = data[pos + 8 : pos + 8 + chunk_size]
+        chunks.append((chunk_id, chunk_data))
+        # Chunks are 2-byte aligned
+        pos += 8 + chunk_size
+        if pos % 2 == 1:
+            pos += 1
+
+    # Rebuild, patching the "stri" (string table) chunk
+    out_chunks = []
+    for chunk_id, chunk_data in chunks:
+        if chunk_id == b"stri":
+            chunk_data = _rewrite_string_table(chunk_data, old_prefix, new_prefix)
+        out_chunks.append((chunk_id, chunk_data))
+
+    # Reassemble RIFF
+    body = b""
+    for chunk_id, chunk_data in out_chunks:
+        body += chunk_id
+        body += struct.pack("<I", len(chunk_data))
+        body += chunk_data
+        if len(chunk_data) % 2 == 1:
+            body += b"\x00"  # padding
+
+    return b"RIFF" + struct.pack("<I", 4 + len(body)) + riff_type + body
+
+
+def _rewrite_string_table(
+    chunk_data: bytes, old_prefix: bytes, new_prefix: bytes
+) -> bytes:
+    # First 4 bytes: uncompressed size (0 = no compression)
+    uncompressed_size = struct.unpack_from("<I", chunk_data, 0)[0]
+
+    if uncompressed_size == 0:
+        # Not compressed — raw null-terminated strings after the size field
+        raw = chunk_data[4:]
+        raw = raw.replace(old_prefix, new_prefix)
+        return struct.pack("<I", 0) + raw
+    else:
+        # zlib compressed
+        compressed = chunk_data[4:]
+        raw = zlib.decompress(compressed)
+        assert len(raw) == uncompressed_size, (
+            f"size mismatch: expected {uncompressed_size}, got {len(raw)}"
+        )
+        raw = raw.replace(old_prefix, new_prefix)
+        recompressed = zlib.compress(raw)
+        return struct.pack("<I", len(raw)) + recompressed
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <index.idx> <old-prefix> <new-prefix>", file=sys.stderr)
+        sys.exit(1)
+
+    idx_path = sys.argv[1]
+    old_prefix = sys.argv[2].encode()
+    new_prefix = sys.argv[3].encode()
+
+    with open(idx_path, "rb") as f:
+        data = f.read()
+
+    data = rewrite_paths(data, old_prefix, new_prefix)
+
+    with open(idx_path, "wb") as f:
+        f.write(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/clangd-indexing-tools.nix
+++ b/tools/clangd-indexing-tools.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook, libgcc, unzip }:
+
+let
+  version = "21.1.8";
+  systems = {
+    x86_64-linux = {
+      url = "https://github.com/clangd/clangd/releases/download/${version}/clangd_indexing_tools-linux-${version}.zip";
+      hash = "sha256-fFoSY1zp4/B5B4kxGgvNPTIFRRz6jJjIsj0FDIIBkyA=";
+    };
+  };
+  platform = systems.${stdenv.hostPlatform.system}
+    or (throw "clangd-indexing-tools: unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "clangd-indexing-tools";
+  inherit version;
+
+  src = fetchurl {
+    inherit (platform) url hash;
+  };
+
+  sourceRoot = "clangd_${version}";
+
+  nativeBuildInputs = [ autoPatchelfHook unzip ];
+  buildInputs = [ stdenv.cc.cc.lib libgcc ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin/
+  '';
+
+  meta = {
+    description = "clangd indexing tools (clangd-indexer, clangd-index-server)";
+    homepage = "https://github.com/clangd/clangd";
+    license = lib.licenses.asl20;
+    platforms = builtins.attrNames systems;
+  };
+}


### PR DESCRIPTION
This PR makes it so that user IDEs (at least, those that use `clangd`) do not need to reindex the entire project - can take a decent amount of time and memory - when they update dx or install it for the first time.

- Add a "Build clangd index" ([what's an index?](https://clangd.llvm.org/design/indexing)) step to the nightly release workflow. This is uploaded to releases.
- `configure.py` downloads the index from the appropriate github release whenever the user updates dx (nearest ancestor commit with `dx-*` tag moves to a new commit sha), and on first run.
- Moved the windows toolchain to `.dx/windows/` so we can avoid spamming the root directory with ephemeral state.