### PR TITLE
fix kmr_04 Goompa cutscene re-enabling player input

### DIFF
--- a/src/world/area_kmr/kmr_04/npc.c
+++ b/src/world/area_kmr/kmr_04/npc.c
@@ -77,7 +77,7 @@ EvtScript N(EVS_NpcAI_Goompa) = {
                 IfGt(LVar2, 85)
                     Goto(10)
                 EndIf
-                Call(DisablePlayerInput, false)
+                Call(DisablePlayerInput, true)
                 Call(N(AwaitPartnerGrounded))
                 Call(DisablePartnerAI, 0)
                 Call(SetNpcFlagBits, NPC_PARTNER, NPC_FLAG_IGNORE_WORLD_COLLISION, true)


### PR DESCRIPTION
Commit e76129538 ("c foliage") refactored the inline include CheckPartnerFlags1000 into the AwaitPartnerGrounded API_CALLABLE and inadvertently flipped the boolean argument on the adjacent DisablePlayerInput call from true to false. The cutscene where Jr. Troopa attacks Goompa flows directly into the Jr. Troopa encounter cutscene before SpeakToPlayer locks the player, so Mario can walk around freely during both cutscenes.