### PR TITLE
Align save globals to dodge PI DMA destination corruption

### DIFF
--- a/src/fio.c
+++ b/src/fio.c
@@ -12,13 +12,13 @@ typedef struct SaveInfo {
 #define GLOBALS_PAGE_1 6
 #define GLOBALS_PAGE_2 7
 
-BSS SaveData FetchSaveBuffer;
+BSS SaveData FetchSaveBuffer ALIGNED8;
 BSS SaveInfo LogicalSaveInfo[4];  // 4 save slots presented to the player
 BSS SaveInfo PhysicalSaveInfo[6]; // 6 saves as represented on the EEPROM
 BSS s32 NextAvailablePhysicalSave;
 
-SaveGlobals gSaveGlobals;
-SaveData gCurrentSaveFile;
+SaveGlobals gSaveGlobals ALIGNED8;
+SaveData gCurrentSaveFile ALIGNED8;
 
 char MagicSaveString[] = "Mario Story 006";
 
@@ -240,6 +240,8 @@ b32 fio_read_flash(s32 pageNum, void* readBuffer, u32 numBytes) {
     s8* buf = (s8*)readBuffer;
     s32 amt;
     u16 i;
+
+    ASSERT_MSG(((u32)buf & 7) == 0, "fio_read_flash: dest not 8-byte aligned");
 
     osInvalDCache(buf, numBytes);
     osCreateMesgQueue(&mesgQueue, &mesg, 1);


### PR DESCRIPTION
gSaveGlobals and gCurrentSaveFile receive PI DMA from flash. The N64 PI engine requires 8-byte aligned RDRAM destinations; misaligned ones hit a hardware bug that drops a few bytes per 128-byte block. Plain BSS placement only guarantees 4-byte alignment, so today it works by accident — whichever offset the linker happens to pick. An unrelated edit that shifts BSS layout can land the globals on a bad offset and the dropped word eats magicString, at which point saves silently fail to load and the slot shows empty.

Force 16-byte alignment (8 is enough; 16 matches the cache line and costs nothing) so it's no longer the linker's problem.

Refs:
  https://n64brew.dev/wiki/Parallel_Interface
  https://github.com/rasky/n64_pi_dma_test