### PR TITLE
add ExecOnActor and ExecWaitOnActor for cross-actor communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ First versioned release. The following changes are relative to [vanilla Paper Ma
     - Backtraces provide filenames and line numbers for files with debug symbols.
 - `assets/star_rod_build` directory for Star Rod to write assets to.
 - Link with [libgcc_vr4300] to provide compiler intrinsics.
+- EVT script instructions `ExecOnActor` and `ExecWaitOnActor`, which are similar to `Exec` and `ExecWait` but execute the script as a specific actor.
+- EVT API function `DoesActorExport` to query whether an actor's overlay exports a symbol.
 
 ### Changed
 

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -1860,6 +1860,7 @@ typedef struct Actor {
     /* 0x000 */ s32 flags;
     /* 0x004 */ s32 flags2;
     /* 0x008 */ struct ActorBlueprint* actorBlueprint;
+    /*       */ struct Overlay* overlay;
     /* 0x00C */ ActorState state;
     /* 0x0C8 */ ActorMovement fly;
     /* 0x124 */ char unk_124[16];

--- a/include/script_api/battle.h
+++ b/include/script_api/battle.h
@@ -1602,6 +1602,32 @@ API_CALLABLE(CancelEnemyTurn);
 /// @param event
 API_CALLABLE(DispatchEventPlayer);
 
+/// @evtapi
+/// @param actor
+/// @param symbolName
+/// @param outResult
+///
+/// Checks whether the given actor's overlay exports a symbol with the given name.
+///
+/// For example, this will exec an exported `EVS_OnHit` script on `ACTOR_ENEMY0` if it has one:
+/// ```
+/// Call(DoesActorExport, ACTOR_ENEMY0, "EVS_OnHit", LVar0)
+/// IfTrue(LVar0)
+///     ExecOnActor(ACTOR_ENEMY0, "EVS_OnHit")
+/// EndIf
+/// ```
+API_CALLABLE(DoesActorExport);
+
+/// Runs an EVT script exported by the given actor's overlay, as that actor,
+/// without waiting for it to finish.
+#define ExecOnActor(actor, scriptName) Call(ExecOnActor_impl, actor, (Bytecode)(scriptName))
+API_CALLABLE(ExecOnActor_impl);
+
+/// Runs an EVT script exported by the given actor's overlay, as that actor,
+/// and waits for it to finish.
+#define ExecWaitOnActor(actor, scriptName) Call(ExecWaitOnActor_impl, actor, (Bytecode)(scriptName))
+API_CALLABLE(ExecWaitOnActor_impl);
+
 extern EvtScript EVS_Mario_HandlePhase;
 extern EvtScript EVS_Peach_HandlePhase;
 extern EvtScript EVS_ExecuteMarioAction;

--- a/src/battle/190B20.c
+++ b/src/battle/190B20.c
@@ -1426,11 +1426,12 @@ Actor* create_actor(Formation formation) {
         z = formation->home.vec->z;
     }
 
+    Overlay* ovl = nullptr;
     if (formation->actor != nullptr) {
         formationActor = formation->actor;
     } else if (formation->overlay != nullptr) {
-        Overlay* mod = ovl_load(formation->overlay, OVL_ACTOR);
-        formationActor = ovl_import(mod, "blueprint");
+        ovl = ovl_load(formation->overlay, OVL_ACTOR);
+        formationActor = ovl_import(ovl, "blueprint");
         ASSERT_MSG(formationActor != nullptr, "Actor '%s' does not export 'blueprint'", formation->overlay);
     } else {
         PANIC();
@@ -1451,6 +1452,7 @@ Actor* create_actor(Formation formation) {
     actor->ordinal = battleStatus->nextActorOrdinal++;
     actor->footStepCounter = 0;
     actor->actorBlueprint = formationActor;
+    actor->overlay = ovl;
     actor->actorType = formationActor->type;
     actor->flags = formationActor->flags;
     actor->homePos.x = actor->curPos.x = x;

--- a/src/battle/actor_api.c
+++ b/src/battle/actor_api.c
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "effects.h"
 #include "battle/battle.h"
+#include "dx/overlay.h"
 
 extern s32 IsGroupHeal;
 extern s8 ApplyingBuff;
@@ -3791,5 +3792,86 @@ API_CALLABLE(CopyBuffs) {
     actorTo->chillOutAmount = actorFrom->chillOutAmount;
     actorTo->chillOutTurns = actorFrom->chillOutTurns;
 
+    return ApiStatus_DONE2;
+}
+
+API_CALLABLE(ExecOnActor_impl) {
+    Bytecode* args = script->ptrReadPos;
+    s32 actorID = evt_get_variable(script, *args++);
+    if (actorID == ACTOR_SELF) actorID = script->owner1.actorID;
+    const char* scriptName = (const char*)evt_get_variable(script, *args++);
+
+    Actor* actor = get_actor(actorID);
+    if (actor == nullptr) {
+        debug_printf("ExecOnActor: no such actor %d\n", actorID);
+        return ApiStatus_DONE2;
+    }
+    if (actor->overlay == nullptr) {
+        debug_printf("ExecOnActor: actor %d has no overlay\n", actorID);
+        return ApiStatus_DONE2;
+    }
+    EvtScript* data = ovl_import(actor->overlay, scriptName);
+    if (data == nullptr) {
+        debug_printf("ExecOnActor: overlay does not export '%s'\n", scriptName);
+        return ApiStatus_DONE2;
+    }
+
+    Evt* newScript = start_script_in_group(data, script->priority, 0, script->groupFlags);
+
+    newScript->owner1.actorID = actorID;
+    newScript->owner2 = script->owner2;
+
+    for (s32 i = 0; i < ARRAY_COUNT(script->varTable); i++) {
+        newScript->varTable[i] = script->varTable[i];
+    }
+
+    for (s32 i = 0; i < ARRAY_COUNT(script->varFlags); i++) {
+        newScript->varFlags[i] = script->varFlags[i];
+    }
+
+    newScript->array = script->array;
+    newScript->flagArray = script->flagArray;
+
+    return ApiStatus_DONE2;
+}
+
+API_CALLABLE(ExecWaitOnActor_impl) {
+    Bytecode* args = script->ptrReadPos;
+    s32 actorID = evt_get_variable(script, *args++);
+    if (actorID == ACTOR_SELF) actorID = script->owner1.actorID;
+    const char* scriptName = (const char*)evt_get_variable(script, *args++);
+
+    Actor* actor = get_actor(actorID);
+    if (actor == nullptr) {
+        debug_printf("ExecWaitOnActor: no such actor %d\n", actorID);
+        return ApiStatus_DONE2;
+    }
+    if (actor->overlay == nullptr) {
+        debug_printf("ExecWaitOnActor: actor %d has no overlay\n", actorID);
+        return ApiStatus_DONE2;
+    }
+    EvtScript* data = ovl_import(actor->overlay, scriptName);
+    if (data == nullptr) {
+        debug_printf("ExecWaitOnActor: overlay does not export '%s'\n", scriptName);
+        return ApiStatus_DONE2;
+    }
+
+    Evt* newScript = start_child_script(script, data, 0);
+    newScript->owner1.actorID = actorID;
+
+    script->curOpcode = EVT_OP_INTERNAL_FETCH;
+    return ApiStatus_FINISH;
+}
+
+API_CALLABLE(DoesActorExport) {
+    Bytecode* args = script->ptrReadPos;
+    s32 actorID = evt_get_variable(script, *args++);
+    if (actorID == ACTOR_SELF) actorID = script->owner1.actorID;
+    const char* symbolName = (const char*)evt_get_variable(script, *args++);
+    Bytecode outVar = *args++;
+
+    Actor* actor = get_actor(actorID);
+    b32 result = actor != nullptr && actor->overlay != nullptr && ovl_import(actor->overlay, symbolName) != nullptr;
+    evt_set_variable(script, outVar, result);
     return ApiStatus_DONE2;
 }


### PR DESCRIPTION
Adds two pseudo-instructions to EVT scripts in battle that can exec exported scripts from other actors.

For example, if LVar0 holds an actor ID and the actor overlay has

    export EvtScript EVS_MyScript = { /* ... */ };

then the following will run that script from another file.

    ExecWaitOnActor(LVar0, "EVS_MyScript")

This is useful for interactions between actors or from items/moves to actors.

Similar to standard Exec/ExecWait, arguments can be passed with local vars and flags.