### PR TITLE
fix evt_handle_thread/child_thread to use EVT_CMD_ARGC

### DIFF
--- a/src/evt/evt.c
+++ b/src/evt/evt.c
@@ -1165,7 +1165,7 @@ ApiStatus evt_handle_thread(Evt* script) {
     Bytecode* endLine = startLine;
     do {
         opcode = *endLine++;
-        nargs = *endLine++;
+        nargs = EVT_CMD_ARGC(*endLine++);
         endLine += nargs;
     } while (opcode != EVT_OP_END_THREAD);
 
@@ -1201,7 +1201,7 @@ ApiStatus evt_handle_child_thread(Evt* script) {
     Bytecode* endLine = startLine;
     do {
         opcode = *endLine++;
-        nargs = *endLine++;
+        nargs = EVT_CMD_ARGC(*endLine++);
         endLine += nargs;
     } while (opcode != EVT_OP_END_CHILD_THREAD);
 


### PR DESCRIPTION
The EVT backtraces commit packed source line numbers into the upper 16 bits of the `argc` field in `EVT_CMD`, requiring `EVT_CMD_ARGC()` to unpack the actual argument count. Several scanning loops were updated, but `evt_handle_thread` and `evt_handle_child_thread` were missed.

These functions scan forward through bytecode to find `EVT_OP_END_THREAD`/`EVT_OP_END_CHILD_THREAD`. Without `EVT_CMD_ARGC`, `nargs` included the packed line number, causing the scan to jump far out of bounds and segfault.

Fixes a crash in `kmr_20` (and any other map using `Thread`/`ChildThread` blocks).