### PR TITLE
add downloadable macOS/Linux toolchain

### DIFF
--- a/.github/workflows/release-dx.yaml
+++ b/.github/workflows/release-dx.yaml
@@ -46,3 +46,33 @@ jobs:
             ${{ steps.repo-name.outputs.repository-name }}.bps
             result-toolchain/papermario-dx-windows.zip
             result-clangd-index/papermario-dx.idx
+
+  release-unix-toolchain:
+    name: Release toolchain (${{ matrix.system }})
+    strategy:
+      matrix:
+        include:
+          - system: x86_64-linux
+            runs-on: ubuntu-latest
+          - system: aarch64-linux
+            runs-on: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            runs-on: macos-14
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ${{ matrix.system == 'aarch64-darwin' && 'papermario-dx-aarch64-darwin' || 'papermario-dx' }}
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build toolchain
+        run: nix build .#unix-toolchain --out-link result-toolchain
+      - name: Upload toolchain
+        uses: softprops/action-gh-release@v2
+        with:
+          files: result-toolchain/papermario-dx-*.zip

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,11 @@ if ! command -v mips-linux-gnu-gcc >/dev/null 2>&1; then
   "$ROOT/tools/unix/download_toolchain.sh"
   export PATH="$TOOLCHAIN_DIR/bin:$PATH"
   export PYTHONPATH="$TOOLCHAIN_DIR/python:$PYTHONPATH"
-  PYTHON="$TOOLCHAIN_DIR/bin/python3"
-else
-  PYTHON=python3
 fi
 
-exec "$PYTHON" tools/build/configure.py "$@"
+if [ ! -f "$ROOT/build.ninja" ]; then
+  echo "Running configure..."
+  "$ROOT/configure"
+fi
+
+exec ninja "$@"

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,11 @@
           src = self;
         };
         pythonDeps = windowsToolchain.passthru.pythonDeps;
+
+        unixToolchain = import ./tools/unix {
+          inherit pkgs nixpkgs-binutils-2_39;
+          mipsCrossGcc = pkgsCross.stdenv.cc;
+        };
         linuxRom = pkgs.runCommand "papermario-linux-rom" {
           nativeBuildInputs = [
             pkgsCross.stdenv.cc
@@ -155,6 +160,7 @@
       in {
         packages = {
           default = linuxRom;
+          unix-toolchain = unixToolchain;
         } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
           windows-toolchain = windowsToolchain;
           windows-rom = windowsToolchain.passthru.wineRom;

--- a/tools/unix/binutils.nix
+++ b/tools/unix/binutils.nix
@@ -1,0 +1,47 @@
+# Build binutils for mips-linux-gnu, natively, from source. Building from
+# source (rather than using nixpkgs' auto-wrapped pkgsCross binutils) avoids
+# wrapper scripts that hardcode /nix/store paths, so the result can be
+# relocated by tools/unix/default.nix's activate.sh.
+{
+  stdenv,
+  buildCC,
+  binutilsSrc,
+  binutilsPatches,
+  binutilsVersion,
+  texinfo,
+  bison,
+  flex,
+  zlib,
+}:
+
+stdenv.mkDerivation {
+  pname = "mips-binutils";
+  version = binutilsVersion;
+
+  src = binutilsSrc;
+  patches = binutilsPatches;
+
+  # buildCC provides the native compiler for build-time tools (e.g. bfd/doc/chew).
+  depsBuildBuild = [ buildCC ];
+  nativeBuildInputs = [ texinfo bison flex ];
+  buildInputs = [ zlib ];
+
+  configureFlags = [
+    "--target=mips-linux-gnu"
+    "--disable-nls"
+    "--disable-werror"
+    "--disable-gdb"
+    "--disable-sim"
+    "--disable-readline"
+    "--with-sysroot=/dev/null"
+    # Binutils' own bundled zlib is old enough that it fails to parse
+    # current libc headers on some platforms (e.g. the macOS SDK's stdio.h).
+    "--with-system-zlib"
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    rm -rf $out/share $out/lib $out/include
+  '';
+}

--- a/tools/unix/default.nix
+++ b/tools/unix/default.nix
@@ -1,0 +1,200 @@
+# Builds a downloadable, self-contained toolchain for the current system
+# (one of x86_64-linux, aarch64-linux, aarch64-darwin - x86_64-darwin is
+# unsupported since nixpkgs-unstable dropped it), analogous to tools/windows
+# for Windows.
+#
+# Unlike the Windows toolchain (a Canadian cross that produces binaries with
+# no /nix/store dependency by construction), these binaries are built
+# natively and link against libraries in /nix/store, which won't exist on a
+# plain (non-Nix) machine. To make them runnable there, this derivation:
+#
+#   1. Copies the full runtime closure of every tool into store/, preserving
+#      each package's own internal layout (so e.g. GCC's relative lookup of
+#      cc1/libexec keeps working unmodified).
+#   2. Symlinks every shared library found anywhere in that closure into a
+#      single flat lib/ directory.
+#   3. Ships a generated activate.sh that, given the toolchain's own
+#      (now-known) absolute install path, rewrites every binary's RPATH (and
+#      on Linux, the ELF interpreter) to point at that lib/ directory -
+#      patchelf on Linux (a static copy is bundled, since the target machine
+#      won't have one), install_name_tool + ad-hoc codesign on macOS (via the
+#      system copies from Xcode Command Line Tools).
+{
+  pkgs,
+  nixpkgs-binutils-2_39,
+  mipsCrossGcc,
+}:
+
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  platformTag = {
+    "x86_64-linux" = "linux-x86_64";
+    "aarch64-linux" = "linux-aarch64";
+    "aarch64-darwin" = "macos-aarch64";
+  }.${system} or (throw "tools/unix: unsupported system ${system}");
+
+  # ELF interpreter names, needed to fix up PT_INTERP after relocation
+  # (only meaningful on Linux; unused on Darwin).
+  interpName = {
+    "x86_64-linux" = "ld-linux-x86-64.so.2";
+    "aarch64-linux" = "ld-linux-aarch64.so.1";
+  }.${system} or null;
+
+  # Extract source, patches, and version from the pinned binutils 2.39 nixpkgs commit.
+  binutilsPkg = (import nixpkgs-binutils-2_39 { system = "x86_64-linux"; }).binutils-unwrapped;
+  # Extract source, patches, and version from the nixpkgs GCC derivation.
+  gccPkg = pkgs.gcc.cc;
+
+  mips-binutils = import ./binutils.nix {
+    stdenv = pkgs.stdenv;
+    buildCC = pkgs.stdenv.cc;
+    binutilsSrc = binutilsPkg.src;
+    binutilsPatches = binutilsPkg.patches;
+    binutilsVersion = binutilsPkg.version;
+    inherit (pkgs) texinfo bison flex zlib;
+  };
+
+  mips-gcc = import ./gcc.nix {
+    stdenv = pkgs.stdenv;
+    buildCC = pkgs.stdenv.cc;
+    gccSrc = gccPkg.src;
+    gccPatches = gccPkg.patches;
+    gccVersion = gccPkg.version;
+    inherit mips-binutils mipsCrossGcc;
+    gmpSrc = pkgs.gmp.src;
+    mpfrSrc = pkgs.mpfr.src;
+    mpcSrc = pkgs.libmpc.src;
+    islSrc = pkgs.isl.src;
+    inherit (pkgs) texinfo bison flex zlib;
+  };
+
+  n64crc = import ./n64crc.nix { stdenv = pkgs.stdenv; };
+  pigment64-native = pkgs.callPackage ../pigment64.nix { };
+  crunch64-native = pkgs.callPackage ../crunch64.nix { };
+  python-packages = import ./python.nix { inherit pkgs; };
+
+  # MIPS glibc headers, borrowed from the reference native cross-compiler for
+  # the same target (this build only compiles `all-gcc`, not target libs).
+  mipsGlibcDev = mipsCrossGcc.libc.dev;
+
+  closureRoots = [
+    mips-binutils
+    mips-gcc
+    n64crc
+    pigment64-native
+    crunch64-native
+    pkgs.ninja
+    pkgs.ccache
+    pkgs.python3
+  ];
+  closure = pkgs.closureInfo { rootPaths = closureRoots; };
+
+  zip = pkgs.runCommand "papermario-dx-${platformTag}-toolchain"
+    {
+      nativeBuildInputs = [ pkgs.zip pkgs.unzip pkgs.coreutils ]
+        ++ pkgs.lib.optional (!isDarwin) pkgs.pkgsStatic.patchelf;
+    }
+    ''
+      dir=papermario-dx-${platformTag}
+      mkdir -p $dir/store $dir/bin $dir/lib
+
+      # Copy the whole runtime closure, preserving each package's own layout.
+      while read -r p; do
+        cp -rL --no-preserve=ownership "$p" "$dir/store/$(basename "$p")"
+      done < ${closure}/store-paths
+      # /nix/store paths are read-only; make our copies writable for
+      # patchelf/install_name_tool later, without disturbing the executable
+      # bits that --no-preserve=mode would otherwise reset.
+      chmod -R u+w "$dir/store"
+
+      # Flatten every shared library into lib/ as relative symlinks, so every
+      # binary can share a single RPATH pointing at lib/.
+      find "$dir/store" -type f \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) | while read -r f; do
+        ln -sf "$(realpath --relative-to="$dir/lib" "$f")" "$dir/lib/$(basename "$f")"
+      done
+
+      # bin/ symlinks for the tools users and ninja invoke directly.
+      link_bin() {
+        f=$(find "$dir/store" -mindepth 3 -maxdepth 3 -path '*/bin/'"$1" | head -n1)
+        [ -n "$f" ] && ln -sf "$(realpath --relative-to="$dir/bin" "$f")" "$dir/bin/$1"
+      }
+      for tool in mips-linux-gnu-gcc mips-linux-gnu-g++ mips-linux-gnu-ld mips-linux-gnu-as \
+                  mips-linux-gnu-ar mips-linux-gnu-nm mips-linux-gnu-objcopy mips-linux-gnu-objdump \
+                  mips-linux-gnu-ranlib mips-linux-gnu-strip \
+                  ninja ccache pigment64 crunch64 n64crc python3; do
+        link_bin "$tool"
+      done
+
+      # MIPS glibc headers (string.h, stdio.h, etc.) in the sysroot.
+      mkdir -p $dir/mips-linux-gnu/sys-include
+      cp -rL ${mipsGlibcDev}/include/* $dir/mips-linux-gnu/sys-include/
+
+      # libstdc++ headers, borrowed from the reference cross-compiler for the
+      # same target, placed in GCC's C++ search path using GCC's own version.
+      gccVersion=$(ls ${mips-gcc}/lib/gcc/mips-linux-gnu)
+      mkdir -p $dir/mips-linux-gnu/include/c++/$gccVersion
+      cp -rL ${mipsCrossGcc.cc}/include/c++/*/* $dir/mips-linux-gnu/include/c++/$gccVersion/
+
+      # Python packages (requirements.txt + requirements_extra.txt), found via
+      # PYTHONPATH rather than baked into the interpreter's own store copy.
+      mkdir -p $dir/python
+      cp -rL --no-preserve=ownership ${python-packages}/* $dir/python/
+      chmod -R u+w $dir/python
+
+      ${pkgs.lib.optionalString (!isDarwin) ''
+        cp ${pkgs.pkgsStatic.patchelf}/bin/patchelf $dir/bin/.patchelf
+      ''}
+
+      cat > $dir/activate.sh << 'ACTIVATE_EOF'
+      #!/bin/sh
+      # Relocates the toolchain to run from its current install path. Must be
+      # run once after extracting, with this directory's own absolute path as
+      # $1 (download_toolchain.sh does this automatically).
+      set -e
+      DIR="$1"
+      ACTIVATE_EOF
+      cat >> $dir/activate.sh << 'ACTIVATE_EOF2'
+      ${if isDarwin then ''
+        find "$DIR/store" -type f | while read -r f; do
+          if file "$f" 2>/dev/null | grep -q 'Mach-O'; then
+            # Mach-O load commands embed the full dependency path (unlike
+            # ELF's bare DT_NEEDED names), so an rpath alone doesn't help -
+            # each /nix/store reference has to be rewritten explicitly.
+            otool -L "$f" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+              case "$dep" in
+                /nix/store/*)
+                  install_name_tool -change "$dep" "$DIR/lib/$(basename "$dep")" "$f" >/dev/null 2>&1 || true
+                  ;;
+              esac
+            done
+            id=$(otool -D "$f" 2>/dev/null | tail -n +2)
+            case "$id" in
+              /nix/store/*)
+                install_name_tool -id "$DIR/lib/$(basename "$id")" "$f" >/dev/null 2>&1 || true
+                ;;
+            esac
+            codesign --force --sign - "$f" >/dev/null 2>&1 || true
+          fi
+        done
+      '' else ''
+        PATCHELF="$DIR/bin/.patchelf"
+        find "$DIR/store" -type f | while read -r f; do
+          if "$PATCHELF" --print-rpath "$f" >/dev/null 2>&1; then
+            "$PATCHELF" --set-rpath "$DIR/lib" "$f" || true
+            if "$PATCHELF" --print-interpreter "$f" >/dev/null 2>&1; then
+              "$PATCHELF" --set-interpreter "$DIR/lib/${interpName}" "$f" || true
+            fi
+          fi
+        done
+      ''}
+      ACTIVATE_EOF2
+      chmod +x $dir/activate.sh
+
+      mkdir -p $out
+      cd $dir/..
+      zip -yr $out/papermario-dx-${platformTag}.zip $dir
+    '';
+in
+zip

--- a/tools/unix/download_toolchain.sh
+++ b/tools/unix/download_toolchain.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Downloads and activates the pre-built macOS/Linux toolchain for the
+# current platform, if it isn't already present and up to date. Mirrors
+# tools/windows/download_toolchain.bat.
+set -e
+
+REPO="bates64/papermario-dx"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DX_DIR="$ROOT/.dx"
+TOOLCHAIN_DIR="$DX_DIR/unix"
+TOOLCHAIN_ZIP="$DX_DIR/papermario-dx-unix.zip"
+TAG_FILE="$DX_DIR/unix-tag"
+
+case "$(uname -s)" in
+  Linux) OS=linux ;;
+  Darwin) OS=macos ;;
+  *)
+    echo "Error: unsupported OS $(uname -s). The downloadable toolchain only supports Linux and macOS." >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64) ARCH=x86_64 ;;
+  arm64 | aarch64) ARCH=aarch64 ;;
+  *)
+    echo "Error: unsupported architecture $(uname -m)." >&2
+    exit 1
+    ;;
+esac
+
+PLATFORM="$OS-$ARCH"
+ASSET="papermario-dx-$PLATFORM.zip"
+
+mkdir -p "$DX_DIR"
+
+# Get the nearest dx-* tag (current commit or ancestor): prefer jj if this is
+# a jj repo, otherwise fall back to git.
+if [ -d "$ROOT/.jj" ] && command -v jj >/dev/null 2>&1; then
+  TAG=$(jj -R "$ROOT" log -r 'latest(tags(glob:"dx-*") & ::@)' --no-graph -T 'self.tags().join("\n")' 2>/dev/null | head -n1)
+  TAG_HASH=$(jj -R "$ROOT" log -r 'latest(tags(glob:"dx-*") & ::@)' --no-graph -T 'commit_id' 2>/dev/null)
+elif command -v git >/dev/null 2>&1; then
+  TAG=$(git -C "$ROOT" describe --tags --abbrev=0 --match 'dx-*' 2>/dev/null || true)
+  # Resolve to the commit hash the tag points to, so a force-moved tag (e.g. a
+  # rolling dx-nightly) is detected as an update rather than reused from cache.
+  TAG_HASH=$(git -C "$ROOT" rev-parse "$TAG^{}" 2>/dev/null || true)
+else
+  echo "Error: this needs jj or git to find the toolchain version to download." >&2
+  echo "Install jj (https://jj-vcs.github.io/jj/latest/install-and-setup/) or git (https://git-scm.com/)." >&2
+  exit 1
+fi
+
+if [ -z "$TAG" ]; then
+  echo "Error: no dx-* tag found in the commit history." >&2
+  echo "The downloadable toolchain requires a tagged release with a pre-built toolchain." >&2
+  exit 1
+fi
+
+NEED_DOWNLOAD=0
+if [ ! -x "$TOOLCHAIN_DIR/bin/mips-linux-gnu-gcc" ]; then
+  NEED_DOWNLOAD=1
+fi
+if [ -f "$TAG_FILE" ]; then
+  CURRENT_TAG=$(cat "$TAG_FILE")
+  if [ "$CURRENT_TAG" != "$TAG_HASH" ]; then
+    NEED_DOWNLOAD=1
+  fi
+elif [ -d "$TOOLCHAIN_DIR" ]; then
+  NEED_DOWNLOAD=1
+fi
+
+if [ "$NEED_DOWNLOAD" = "1" ]; then
+  echo "Downloading toolchain for $TAG ($PLATFORM)..." >&2
+
+  rm -rf "$TOOLCHAIN_DIR" "$TOOLCHAIN_ZIP"
+
+  URL="https://github.com/$REPO/releases/download/$TAG/$ASSET"
+  if ! curl -fL -o "$TOOLCHAIN_ZIP" "$URL"; then
+    echo "Error: failed to download toolchain from $URL" >&2
+    exit 1
+  fi
+
+  echo "Extracting toolchain..." >&2
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q "$TOOLCHAIN_ZIP" -d "$DX_DIR"
+  else
+    tar -xf "$TOOLCHAIN_ZIP" -C "$DX_DIR"
+  fi
+  mv "$DX_DIR/papermario-dx-$PLATFORM" "$TOOLCHAIN_DIR"
+  rm -f "$TOOLCHAIN_ZIP"
+
+  echo "Activating toolchain..." >&2
+  if [ "$OS" = "macos" ] && ! command -v install_name_tool >/dev/null 2>&1; then
+    echo "Error: install_name_tool is not installed. Install the Xcode Command Line Tools with: xcode-select --install" >&2
+    exit 1
+  fi
+  "$TOOLCHAIN_DIR/activate.sh" "$TOOLCHAIN_DIR"
+
+  echo "$TAG_HASH" > "$TAG_FILE"
+fi

--- a/tools/unix/gcc.nix
+++ b/tools/unix/gcc.nix
@@ -1,0 +1,102 @@
+# Build GCC for mips-linux-gnu, natively, from source (only the driver and
+# frontends, i.e. `make all-gcc` - not target libgcc/libstdc++). See
+# tools/unix/binutils.nix for why this is built from source rather than via
+# nixpkgs' pkgsCross wrapper.
+{
+  stdenv,
+  buildCC,
+  gccSrc,
+  gccPatches,
+  gccVersion,
+  mips-binutils,
+  mipsCrossGcc,
+  gmpSrc,
+  mpfrSrc,
+  mpcSrc,
+  islSrc,
+  texinfo,
+  bison,
+  flex,
+  zlib,
+}:
+
+stdenv.mkDerivation {
+  pname = "mips-gcc";
+  version = gccVersion;
+
+  src = gccSrc;
+  patches = gccPatches;
+
+  hardeningDisable = [ "format" ];
+
+  depsBuildBuild = [ buildCC ];
+  nativeBuildInputs = [ texinfo bison flex ];
+  buildInputs = [ zlib ];
+
+  # Place prerequisite sources inside the GCC tree for in-tree build.
+  # GCC's configure detects these directories and builds them automatically.
+  postUnpack = ''
+    pushd $sourceRoot
+    tar xf ${gmpSrc} && mv gmp-* gmp
+    tar xf ${mpfrSrc} && mv mpfr-* mpfr
+    tar xf ${mpcSrc} && mv mpc-* mpc
+    tar xf ${islSrc} && mv isl-* isl
+    popd
+  '';
+
+  configureFlags = [
+    "--target=mips-linux-gnu"
+    "--with-headers=${mipsCrossGcc.libc.dev}/include"
+    "--enable-languages=c,c++"
+    "--with-arch=vr4300"
+    "--with-tune=vr4300"
+    "--with-abi=32"
+    "--disable-shared"
+    "--disable-threads"
+    "--disable-tls"
+    "--disable-multilib"
+    "--disable-libssp"
+    "--disable-libgomp"
+    "--disable-libquadmath"
+    "--disable-libatomic"
+    "--disable-libsanitizer"
+    "--disable-libvtv"
+    "--disable-bootstrap"
+    "--disable-nls"
+    "--with-system-zlib"
+  ];
+
+  # Place binutils at the standard GCC search path (<prefix>/mips-linux-gnu/bin/)
+  # so GCC finds them via relative lookup instead of hardcoded nix store paths.
+  preConfigure = ''
+    export gcc_cv_as_compress_debug=1
+    export gcc_cv_ld_compress_debug=1
+    mkdir -p $out/mips-linux-gnu/bin
+    for tool in ${mips-binutils}/bin/mips-linux-gnu-*; do
+      name=$(basename "$tool" | sed 's/^mips-linux-gnu-//')
+      ln -s "$tool" $out/mips-linux-gnu/bin/$name
+    done
+    # Place glibc headers in the sysroot so GCC finds them during build
+    mkdir -p $out/mips-linux-gnu/sys-include
+    cp -rL ${mipsCrossGcc.libc.dev}/include/* $out/mips-linux-gnu/sys-include/
+  '';
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    runHook preBuild
+    make all-gcc
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make install-gcc DESTDIR=
+    rm -rf $out/share $out/include
+    # Keep lib/gcc/.../include (GCC built-in headers like stddef.h)
+    # but remove libraries we don't need.
+    find $out/lib -name '*.a' -delete 2>/dev/null || true
+    find $out/lib -name '*.la' -delete 2>/dev/null || true
+    runHook postInstall
+  '';
+}

--- a/tools/unix/n64crc.nix
+++ b/tools/unix/n64crc.nix
@@ -1,0 +1,20 @@
+# Native build of n64crc.c, pre-built so the downloadable toolchain doesn't
+# depend on the user already having a host C compiler.
+{
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "n64crc";
+  version = "0";
+  dontUnpack = true;
+
+  buildPhase = ''
+    $CC -O2 -o n64crc ${../build/rom/n64crc.c}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp n64crc $out/bin/
+  '';
+}

--- a/tools/unix/python.nix
+++ b/tools/unix/python.nix
@@ -1,0 +1,47 @@
+# Python packages (requirements.txt + requirements_extra.txt) for bundling
+# into the downloadable toolchain. Downloaded natively for the current
+# platform, so pip resolves the correct wheels without cross-platform flags
+# (contrast tools/windows/default.nix's pythonDepsWindows, which has to fetch
+# win_amd64 wheels from a Linux build machine).
+{ pkgs }:
+
+let
+  requirements = ../../requirements.txt;
+  requirementsExtra = ../../requirements_extra.txt;
+  requirementsDigest = builtins.substring 0 8 (builtins.hashFile "sha256" requirements);
+
+  # Each platform resolves a different set of wheels, so each needs its own
+  # hash. Fixed-output derivation, so it's allowed network access in the Nix
+  # sandbox. Update an entry by running the build once: it fails on hash
+  # mismatch and reports the correct value to paste in.
+  wheelHashes = {
+    "x86_64-linux" = "sha256-fE/68DoCfnoaIN8nVjnfe8+XKbsfBsSXBPlPEgVc8WQ=";
+    "aarch64-linux" = "sha256-aOgCFi6gQhCTAC1MzoX5TcBunoDFUsizvRZYzkgq+4g=";
+    "aarch64-darwin" = "sha256-UE+EqFe+LEM9OFF76GdUcW/HXe9bpPzDsD1dY3L/R6M=";
+  };
+
+  wheels = pkgs.stdenvNoCC.mkDerivation {
+    name = "papermario-python-wheels-${pkgs.stdenv.hostPlatform.system}-${requirementsDigest}";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = wheelHashes.${pkgs.stdenv.hostPlatform.system};
+    nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.pip pkgs.cacert ];
+    buildCommand = ''
+      export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+      pip download -r ${requirements} -r ${requirementsExtra} setuptools wheel -d $out
+    '';
+  };
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "papermario-python-packages";
+  version = "0";
+  dontUnpack = true;
+
+  nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.pip ];
+
+  installPhase = ''
+    mkdir -p $out
+    pip install --no-index --find-links=${wheels} --target $out \
+      -r ${requirements} -r ${requirementsExtra} --quiet
+  '';
+}

--- a/tools/windows/download_toolchain.bat
+++ b/tools/windows/download_toolchain.bat
@@ -3,27 +3,48 @@
 :: Ensure .dx directory exists
 if not exist "%DX_DIR%" mkdir "%DX_DIR%"
 
-:: Check for git
+:: Get the nearest dx-* tag (current commit or ancestor): prefer jj if this
+:: is a jj repo, otherwise fall back to git.
+set "HAVE_JJ=0"
+if exist ".jj" (
+    where jj >nul 2>nul
+    if not errorlevel 1 set "HAVE_JJ=1"
+)
+set "HAVE_GIT=0"
 where git >nul 2>nul
-if errorlevel 1 (
-    echo Error: git is not installed. Install it from https://git-scm.com/ or via: winget install Git.Git
+if not errorlevel 1 set "HAVE_GIT=1"
+
+if "%HAVE_JJ%"=="0" if "%HAVE_GIT%"=="0" (
+    echo Error: this needs jj or git to find the toolchain version to download.
+    echo Install jj: https://jj-vcs.github.io/jj/latest/install-and-setup/
+    echo Or install git: https://git-scm.com/ ^(or: winget install Git.Git^)
     exit /b 1
 )
 
-:: Get the nearest dx-* tag (current commit or ancestor)
-git describe --tags --abbrev=0 --match dx-* > "%TEMP%\dx-tag.txt" 2>nul
-set /p TAG=<"%TEMP%\dx-tag.txt"
-del "%TEMP%\dx-tag.txt" 2>nul
+set "TAG="
+set "TAG_HASH="
+if "%HAVE_JJ%"=="1" (
+    for /f "usebackq delims=" %%T in (`jj log -r "latest(tags(glob:'dx-*') & ::@)" --no-graph -T "self.tags().join('|')" 2^>nul`) do if not defined TAG set "TAG=%%T"
+    if defined TAG (
+        for /f "usebackq delims=" %%H in (`jj log -r "latest(tags(glob:'dx-*') & ::@)" --no-graph -T "commit_id" 2^>nul`) do set "TAG_HASH=%%H"
+    )
+) else (
+    git describe --tags --abbrev=0 --match dx-* > "%TEMP%\dx-tag.txt" 2>nul
+    set /p TAG=<"%TEMP%\dx-tag.txt"
+    del "%TEMP%\dx-tag.txt" 2>nul
+    if defined TAG (
+        :: Get the commit hash the tag points to (detects force-moved tags like dx-nightly)
+        git rev-parse "!TAG!^{}" > "%TEMP%\dx-tag-hash.txt" 2>nul
+        set /p TAG_HASH=<"%TEMP%\dx-tag-hash.txt"
+        del "%TEMP%\dx-tag-hash.txt" 2>nul
+    )
+)
+
 if not defined TAG (
     echo Error: no dx-* tag found in the commit history.
     echo The Windows build requires a tagged release with a pre-built toolchain.
     exit /b 1
 )
-
-:: Get the commit hash the tag points to (detects force-moved tags like dx-nightly)
-git rev-parse "%TAG%^{}" > "%TEMP%\dx-tag-hash.txt" 2>nul
-set /p TAG_HASH=<"%TEMP%\dx-tag-hash.txt"
-del "%TEMP%\dx-tag-hash.txt" 2>nul
 
 :: Check if toolchain needs downloading
 set "NEED_DOWNLOAD=0"


### PR DESCRIPTION
Lets you build on macOS and Linux without installing Nix. `./configure` (and new `./build.sh`) fetch a pre-built toolchain for your platform if `mips-linux-gnu-gcc` isn't already on PATH, the same way the existing Windows flow already works. `nix develop` users see no change - the download only kicks in when the toolchain isn't already available.